### PR TITLE
Add domains

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -165,6 +165,12 @@ version = "4.7.0"
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
+[[Dierckx]]
+deps = ["BinaryProvider", "Libdl", "Random", "Test"]
+git-tree-sha1 = "27a74763c20938a814da26f31a9e8408d16fec44"
+uuid = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"
+version = "0.4.1"
+
 [[DiffBase]]
 deps = ["StaticArrays"]
 git-tree-sha1 = "38522d70e417cf9ace93848f17eb9fff20d486d2"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Clp = "e2554f3b-3117-50c0-817c-e040a3ddf72d"
+Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"

--- a/REQUIRE
+++ b/REQUIRE
@@ -12,3 +12,4 @@ IterTools
 SpecialFunctions
 Images
 PyPlot
+Dierckx

--- a/iJulia/ParametrizedTConstantVOctaneOxidation.ipynb
+++ b/iJulia/ParametrizedTConstantVOctaneOxidation.ipynb
@@ -1,0 +1,130 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using DifferentialEquations\n",
+    "using PyPlot\n",
+    "using ReactionMechanismSimulator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phaseDict = readinput(\"../src/testing/liquid_phase.rms\") #load mechanism dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spcs = phaseDict[\"phase\"][\"Species\"]; #mechanism dictionaries index:  phaseDict[phasename][\"Species\" or \"Reactions\"]\n",
+    "rxns = phaseDict[\"phase\"][\"Reactions\"];"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "solv = Solvent(\"octane\",RiedelViscosity(-98.805,3905.5,14.103,-2.5112e-5,2.0));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "liq = IdealDiluteSolution(spcs,rxns,solv;name=\"phase\",diffusionlimited=true); #Define the phase (how species thermodynamic and kinetic properties calculated)\n",
+    "#Tfcn(x::Float64) = 450.0\n",
+    "#initialconds = Dict([\"T\"=>Tfcn,\"V\"=>1.0e-6*1e6,\"octane\"=>6.154e-3*1e6,\"oxygen\"=>4.953e-6*1e6]); #Set simulation Initial Temp and Pressure\n",
+    "initialconds = Dict([\"ts\"=>[0.0,10000.0,100000.0,200000.0],\"T\"=>[450.0,500.0,600.0,700.0],\"V\"=>1.0e-6*1e6,\"octane\"=>6.154e-3*1e6,\"oxygen\"=>4.953e-6*1e6]); #Set simulation Initial Temp and Pressure\n",
+    "domain,y0 = ParametrizedTConstantVDomain(phase=liq,initialconds=initialconds,\n",
+    "    constantspecies=[\"oxygen\"]); #Define the domain (encodes how system thermodynamic properties calculated)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "react = Reactor(domain,y0,(0.0,140000.01)); #Create the reactor object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "sol = solve(react.ode,DifferentialEquations.CVODE_BDF(),abstol=1e-20,reltol=1e-8); #solve the ode associated with the reactor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bsol = Simulation(sol,domain);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotmolefractions(bsol,140000.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "getfluxdiagram(bsol,100000.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "@webio": {
+   "lastCommId": "6af425ce410441c3a55e55708400249b",
+   "lastKernelId": "195d926f-77fb-4ca7-91ea-24e1628c3ae0"
+  },
+  "kernelspec": {
+   "display_name": "Julia 1.0.0",
+   "language": "julia",
+   "name": "julia-1.0"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.0.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/iJulia/ParametrizedTPH2Combustion.ipynb
+++ b/iJulia/ParametrizedTPH2Combustion.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using DifferentialEquations\n",
+    "using PyPlot\n",
+    "using ReactionMechanismSimulator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phaseDict = readinput(\"../src/testing/superminimal.rms\") #load mechanism dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spcs = phaseDict[\"gas\"][\"Species\"]; #mechanism dictionaries index:  phaseDict[phasename][\"Species\" or \"Reactions\"]\n",
+    "rxns = phaseDict[\"gas\"][\"Reactions\"];"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ig = IdealGas(spcs,rxns,name=\"gas\"); #Define the phase (how species thermodynamic and kinetic properties calculated)\n",
+    "#Tfcn(x::Float64) = 1000.0+10.0*x\n",
+    "#Pfcn(x::Float64) = 1e5\n",
+    "#initialconds = Dict([\"T\"=>Tfcn,\"P\"=>Pfcn,\"H2\"=>0.67,\"O2\"=>0.33]); #Set simulation Initial Temp and Pressure\n",
+    "initialconds = Dict([\"T\"=>[1000.0,1100.0,1200.0,1300.0,1400.0],\"ts\"=>[0.0,20.0,50.0,100.0,140.0],\"P\"=>[1.0e5,1.0e5,1.0e5,1.0e5,1.0e5],\"H2\"=>0.67,\"O2\"=>0.33]); #Set simulation Initial Temp and Pressure\n",
+    "domain,y0 = ParametrizedTPDomain(phase=ig,initialconds=initialconds); #Define the domain (encodes how system thermodynamic properties calculated)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "react = Reactor(domain,y0,(0.0,150.1)); #Create the reactor object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "sol = solve(react.ode,DifferentialEquations.CVODE_BDF(),abstol=1e-20,reltol=1e-12); #solve the ode associated with the reactor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bsol = Simulation(sol,domain);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotmolefractions(bsol,150.0; t0=1e-15, N=1000, tol=0.01)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotrops(bsol,\"OH(D)\",tol=0.01)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "@webio": {
+   "lastCommId": "8cd25b334afb4fad8a5e694f67c89798",
+   "lastKernelId": "33c6aacc-e57e-4c26-a2fb-af1087567e09"
+  },
+  "kernelspec": {
+   "display_name": "Julia 1.0.0",
+   "language": "julia",
+   "name": "julia-1.0"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.0.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/iJulia/ParametrizedVH2Combustion.ipynb
+++ b/iJulia/ParametrizedVH2Combustion.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using DifferentialEquations\n",
+    "using PyPlot\n",
+    "using ReactionMechanismSimulator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phaseDict = readinput(\"../src/testing/superminimal.rms\") #load mechanism dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spcs = phaseDict[\"gas\"][\"Species\"]; #mechanism dictionaries index:  phaseDict[phasename][\"Species\" or \"Reactions\"]\n",
+    "rxns = phaseDict[\"gas\"][\"Reactions\"];"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ig = IdealGas(spcs,rxns,name=\"gas\"); #Define the phase (how species thermodynamic and kinetic properties calculated)\n",
+    "initialconds = Dict([\"T\"=>1000.0,\"ts\"=>[0.0,0.02,0.04,0.05],\"V\"=>[0.008314,0.01,0.012,0.012],\"H2\"=>0.67,\"O2\"=>0.33]); #Set simulation Initial Temp and Pressure\n",
+    "#f(x::Float64) = 0.008314\n",
+    "#initialconds = Dict([\"T\"=>1000.0,\"V\"=>f,\"H2\"=>0.67,\"O2\"=>0.33]); #Set simulation Initial Temp and Pressure\n",
+    "domain,y0 = ParametrizedVDomain(phase=ig,initialconds=initialconds); #Define the domain (encodes how system thermodynamic properties calculated)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "react = Reactor(domain,y0,(0.0,0.0501)); #Create the reactor object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "sol = solve(react.ode,DifferentialEquations.CVODE_BDF(),abstol=1e-20,reltol=1e-8); #solve the ode associated with the reactor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bsol = Simulation(sol,domain);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotmolefractions(bsol,0.05; t0=1e-15, N=1000, tol=0.01)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ts = exp.(range(log(1e-15),length=1000,stop=log(0.05)))\n",
+    "plot(ts,[sol(t)[domain.indexes[end]] for t in ts]) #Temperature vs time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ts[argmax(diff([sol(t)[end] for t in ts]))] #Ignition Delay Time in seconds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "getfluxdiagram(bsol,0.036,centralspecieslist=[\"OH(D)\"],radius=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotrops(bsol,\"OH(D)\",0.01;tol=0.001)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.0.0",
+   "language": "julia",
+   "name": "julia-1.0"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.0.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -437,7 +437,7 @@ export calcthermo
     end
 end
 
-@inline function calcdomainderivatives!(d::ConstantVDomain{W,Y},dydt::Array{K,1};T::Z4,Us::Array{Z,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real}
+@inline function calcdomainderivatives!(d::Union{ConstantVDomain{W,Y},ParametrizedVDomain{W,Y}},dydt::Array{K,1};T::Z4,Us::Array{Z,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real}
     @views @fastmath @inbounds dydt[d.indexes[3]] = -dot(Us,dydt[d.indexes[1]:d.indexes[2]])/(N*Cvave) #divide by V to cancel ωV to ω
     for ind in d.constantspeciesinds #make dydt zero for constant species
         @inbounds dydt[ind] = 0.0

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -385,6 +385,38 @@ end
     return ns,cs,T,P,d.V,C,N,0.0,kfs,krevs,[],Us,Gs,diffs,Cvave
 end
 
+@inline function calcthermo(d::ParametrizedVDomain{W,Y},y::J,t::Q) where {W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    V = d.V(t)
+    ns = y[d.indexes[1]:d.indexes[2]]
+    T = y[d.indexes[3]]
+    N = sum(ns)
+    cs = ns./V
+    C = N/V
+    P = C*R*T
+    Gs = zeros(length(d.phase.species))
+    Us = zeros(length(d.phase.species))
+    Cvave = 0.0
+    @simd for i = 1:length(d.phase.species)
+        @inbounds cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.species[i].thermo,T)
+        @fastmath @inbounds Gs[i] = (hdivRT-sdivR)*R*T
+        @fastmath @inbounds Us[i] = (hdivRT-1.0)*R*T
+        @fastmath @inbounds Cvave += cpdivR*ns[i]
+    end
+    @fastmath Cvave *= R/N
+    @fastmath Cvave -= R
+    if d.phase.diffusionlimited
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
+    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,[],Us,Gs,diffs,Cvave
+end
+
 @inline function calcthermo(d::ConstantTVDomain{W,Y},y::J,t::Q) where {W<:IdealDiluteSolution,Y<:Integer,J<:AbstractArray,Q<:Real}
     if t != d.t[1]
         d.t[1] = t

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1,6 +1,7 @@
 using Parameters
 using LinearAlgebra
 using StaticArrays
+using Dierckx
 
 abstract type AbstractDomain end
 export AbstractDomain

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -53,18 +53,22 @@ export molefractions
 
 getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantTPDomain,ConstantTVDomain},K<:Real,Q,G,L} = bsol.domain.T
 getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ParametrizedVDomain},K<:Real,Q,G,L} = bsol.sol(t)[bsol.domain.indexes[3]]
+getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedTPDomain,K<:Real,Q,G,L} = bsol.domain.T(t)
 export getT
 getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTPDomain,K<:Real,Q,G,L} = bsol.N(t)*getT(bsol,t)*R /bsol.domain.P
 getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ConstantTVDomain},K<:Real,Q,G,L} = bsol.domain.V
 getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedVDomain,K<:Real,Q,G,L} = bsol.domain.V(t)
+getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedTPDomain,K<:Real,Q,G,L} = bsol.N(t)*getT(bsol,t)*R /bsol.domain.P(t)
 export getV
 getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTPDomain,K<:Real,Q,G,L} = bsol.domain.P
 getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTVDomain,K<:Real,Q,G,L} = 1.0e6
 getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ParametrizedVDomain},K<:Real,Q,G,L} = bsol.N(t)*R*getT(bsol,t)/getV(bsol,t)
+getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedTPDomain,K<:Real,Q,G,L} = bsol.domain.P(t)
 export getP
 getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTPDomain,K<:Real,Q,G,L} = bsol.domain.P/(R*bsol.domain.T)
 getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ConstantTVDomain},K<:Real,Q,G,L} = bsol.N(t)/bsol.domain.V
 getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedVDomain,K<:Real,Q,G,L} = bsol.N(t)/bsol.domain.V(t)
+getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedTPDomain,K<:Real,Q,G,L} = bsol.domain.P(t)/(R*bsol.domain.T(t))
 export getC
 """
 calculates the rates of production/loss at a given time point

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -52,17 +52,19 @@ end
 export molefractions
 
 getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantTPDomain,ConstantTVDomain},K<:Real,Q,G,L} = bsol.domain.T
-getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantVDomain,K<:Real,Q,G,L} = bsol.sol(t)[bsol.domain.indexes[3]]
+getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ParametrizedVDomain},K<:Real,Q,G,L} = bsol.sol(t)[bsol.domain.indexes[3]]
 export getT
 getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTPDomain,K<:Real,Q,G,L} = bsol.N(t)*getT(bsol,t)*R /bsol.domain.P
 getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ConstantTVDomain},K<:Real,Q,G,L} = bsol.domain.V
+getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedVDomain,K<:Real,Q,G,L} = bsol.domain.V(t)
 export getV
 getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTPDomain,K<:Real,Q,G,L} = bsol.domain.P
 getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTVDomain,K<:Real,Q,G,L} = 1.0e6
-getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantVDomain,K<:Real,Q,G,L} = bsol.N(t)*R*getT(bsol,t)/getV(bsol,t)
+getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ParametrizedVDomain},K<:Real,Q,G,L} = bsol.N(t)*R*getT(bsol,t)/getV(bsol,t)
 export getP
 getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTPDomain,K<:Real,Q,G,L} = bsol.domain.P/(R*bsol.domain.T)
 getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ConstantTVDomain},K<:Real,Q,G,L} = bsol.N(t)/bsol.domain.V
+getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedVDomain,K<:Real,Q,G,L} = bsol.N(t)/bsol.domain.V(t)
 export getC
 """
 calculates the rates of production/loss at a given time point

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -53,20 +53,20 @@ export molefractions
 
 getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantTPDomain,ConstantTVDomain},K<:Real,Q,G,L} = bsol.domain.T
 getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ParametrizedVDomain},K<:Real,Q,G,L} = bsol.sol(t)[bsol.domain.indexes[3]]
-getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedTPDomain,K<:Real,Q,G,L} = bsol.domain.T(t)
+getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ParametrizedTConstantVDomain,ParametrizedTPDomain},K<:Real,Q,G,L} = bsol.domain.T(t)
 export getT
 getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTPDomain,K<:Real,Q,G,L} = bsol.N(t)*getT(bsol,t)*R /bsol.domain.P
-getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ConstantTVDomain},K<:Real,Q,G,L} = bsol.domain.V
+getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ConstantTVDomain,ParametrizedTConstantVDomain},K<:Real,Q,G,L} = bsol.domain.V
 getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedVDomain,K<:Real,Q,G,L} = bsol.domain.V(t)
 getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedTPDomain,K<:Real,Q,G,L} = bsol.N(t)*getT(bsol,t)*R /bsol.domain.P(t)
 export getV
 getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTPDomain,K<:Real,Q,G,L} = bsol.domain.P
-getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTVDomain,K<:Real,Q,G,L} = 1.0e6
+getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantTVDomain,ParametrizedTConstantVDomain},K<:Real,Q,G,L} = 1.0e6
 getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ParametrizedVDomain},K<:Real,Q,G,L} = bsol.N(t)*R*getT(bsol,t)/getV(bsol,t)
 getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedTPDomain,K<:Real,Q,G,L} = bsol.domain.P(t)
 export getP
 getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTPDomain,K<:Real,Q,G,L} = bsol.domain.P/(R*bsol.domain.T)
-getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ConstantTVDomain},K<:Real,Q,G,L} = bsol.N(t)/bsol.domain.V
+getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ConstantTVDomain,ParametrizedTConstantVDomain},K<:Real,Q,G,L} = bsol.N(t)/bsol.domain.V
 getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedVDomain,K<:Real,Q,G,L} = bsol.N(t)/bsol.domain.V(t)
 getC(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedTPDomain,K<:Real,Q,G,L} = bsol.domain.P(t)/(R*bsol.domain.T(t))
 export getC


### PR DESCRIPTION
Add domains for simulating adiabatic reactions where volume varies as a function of time.  Reactors where temperature and pressure are defined as a function of time.  And liquid reactors where temperature is defined as a function of time and the volume is kept constant.  

This doesn't include sensitivity capabilities yet although I believe the parameter jacobians just need to be generalized and the system jacobians need to be forced to include time as a variable.  Doing that will involve some changes to sensitivity reading and so are not included in this PR.  