### PR TITLE
Inlets and Outlets

### DIFF
--- a/src/Calculators/ThermoUncertainty.jl
+++ b/src/Calculators/ThermoUncertainty.jl
@@ -1,8 +1,10 @@
 using Parameters
 
 abstract type AbstractThermoUncertainty end
+export AbstractThermoUncertainty
 
 struct EmptyThermoUncertainty <: AbstractThermoUncertainty end
+export EmptyThermoUncertainty
 
 @with_kw struct ConstantThermoUncertainty <: AbstractThermoUncertainty
     u::AbstractFloat = nothing

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -15,7 +15,6 @@ export AbstractVariableKDomain
 
 @with_kw struct ConstantTPDomain{N<:AbstractPhase,S<:Integer,W<:Real, W2<:Real, I<:Integer, Q<:AbstractArray} <: AbstractConstantKDomain
     phase::N
-    interfaces::Array{AbstractInterface,1} = Array{AbstractInterface,1}()
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     T::W
@@ -32,7 +31,7 @@ export AbstractVariableKDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
 end
-function ConstantTPDomain(;phase::E2,interfaces::Array{Q,1}=Array{EmptyInterface,1}(),initialconds::Dict{X,X2},constantspecies::Array{X3,1}=Array{String,1}(),
+function ConstantTPDomain(;phase::E2,initialconds::Dict{X,X2},constantspecies::Array{X3,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {E<:Real,E2<:AbstractPhase,Q<:AbstractInterface,W<:Real,X,X2,X3}
     #set conditions and initialconditions
     T = 0.0
@@ -88,14 +87,13 @@ function ConstantTPDomain(;phase::E2,interfaces::Array{Q,1}=Array{EmptyInterface
         jacobian=zeros(typeof(T),length(phase.species),length(phase.species))
     end
     rxnarray = getreactionindices(phase)
-    return ConstantTPDomain(phase,interfaces,SVector(phase.species[1].index,phase.species[end].index),constspcinds,
+    return ConstantTPDomain(phase,SVector(phase.species[1].index,phase.species[end].index),constspcinds,
         T,P,kfs,krevs,efficiencyinds,Gs,rxnarray,mu,diffs,jacobian,sensitivity,MVector(false),MVector(0.0)), y0
 end
 export ConstantTPDomain
 
 @with_kw struct ConstantVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
-    interfaces::Array{AbstractInterface,1} = Array{AbstractInterface,1}()
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     V::W
@@ -105,7 +103,7 @@ export ConstantTPDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
 end
-function ConstantVDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterface,1}(),initialconds::Dict{X,E},constantspecies::Array{X2,1}=Array{String,1}(),
+function ConstantVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {E,X,X2,Z<:IdealGas,Q<:AbstractInterface}
 
     #set conditions and initialconditions
@@ -155,14 +153,13 @@ function ConstantVDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterface,1
         jacobian=zeros(typeof(T),length(phase.species)+1,length(phase.species)+1)
     end
     rxnarray = getreactionindices(phase)
-    return ConstantVDomain(phase,interfaces,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1),constspcinds,
+    return ConstantVDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1),constspcinds,
     V,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0)), y0
 end
 export ConstantVDomain
 
 @with_kw struct ConstantPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
-    interfaces::Array{AbstractInterface,1} = Array{AbstractInterface,1}()
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     P::W
@@ -172,7 +169,7 @@ export ConstantVDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
 end
-function ConstantPDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterface,1}(),initialconds::Dict{X,E},constantspecies::Array{X2,1}=Array{String,1}(),
+function ConstantPDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {E,X,X2,Z<:IdealGas,Q<:AbstractInterface}
 
     #set conditions and initialconditions
@@ -222,14 +219,13 @@ function ConstantPDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterface,1
         jacobian=zeros(typeof(T),length(phase.species)+1,length(phase.species)+1)
     end
     rxnarray = getreactionindices(phase)
-    return ConstantPDomain(phase,interfaces,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1),constspcinds,
+    return ConstantPDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1),constspcinds,
     P,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0)), y0
 end
 export ConstantPDomain
 
 @with_kw struct ParametrizedTPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
-    interfaces::Array{AbstractInterface,1} = Array{AbstractInterface,1}()
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     T::Function
@@ -240,7 +236,7 @@ export ConstantPDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
 end
-function ParametrizedTPDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterface,1}(),initialconds::Dict{X,Any},constantspecies::Array{X2,1}=Array{String,1}(),
+function ParametrizedTPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {X,X2,Z<:IdealGas,Q<:AbstractInterface}
 
     #set conditions and initialconditions
@@ -306,14 +302,13 @@ function ParametrizedTPDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterf
         jacobian=zeros(typeof(V),length(phase.species)+1,length(phase.species)+1)
     end
     rxnarray = getreactionindices(phase)
-    return ParametrizedTPDomain(phase,interfaces,SVector(phase.species[1].index,phase.species[end].index),constspcinds,
+    return ParametrizedTPDomain(phase,SVector(phase.species[1].index,phase.species[end].index),constspcinds,
     Tfcn,Pfcn,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0)), y0
 end
 export ParametrizedTPDomain
 
 @with_kw struct ParametrizedVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
-    interfaces::Array{AbstractInterface,1} = Array{AbstractInterface,1}()
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     V::Function
@@ -323,7 +318,7 @@ export ParametrizedTPDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
 end
-function ParametrizedVDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterface,1}(),initialconds::Dict{X,Any},constantspecies::Array{X2,1}=Array{String,1}(),
+function ParametrizedVDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {X,X2,E<:Real,Z<:IdealGas,Q<:AbstractInterface}
 
     #set conditions and initialconditions
@@ -383,14 +378,13 @@ function ParametrizedVDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterfa
         jacobian=zeros(typeof(T),length(phase.species)+1,length(phase.species)+1)
     end
     rxnarray = getreactionindices(phase)
-    return ParametrizedVDomain(phase,interfaces,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1),constspcinds,
+    return ParametrizedVDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1),constspcinds,
     Vfcn,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0)), y0
 end
 export ParametrizedVDomain
 
 @with_kw struct ParametrizedPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
-    interfaces::Array{AbstractInterface,1} = Array{AbstractInterface,1}()
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     P::Function
@@ -400,7 +394,7 @@ export ParametrizedVDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
 end
-function ParametrizedPDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterface,1}(),initialconds::Dict{X,Any},constantspecies::Array{X2,1}=Array{String,1}(),
+function ParametrizedPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {X,X2,E<:Real,Z<:IdealGas,Q<:AbstractInterface}
 
     #set conditions and initialconditions
@@ -460,14 +454,13 @@ function ParametrizedPDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterfa
         jacobian=zeros(typeof(T),length(phase.species)+1,length(phase.species)+1)
     end
     rxnarray = getreactionindices(phase)
-    return ParametrizedPDomain(phase,interfaces,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1),constspcinds,
+    return ParametrizedPDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1),constspcinds,
     Pfcn,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0)), y0
 end
 export ParametrizedPDomain
 
 @with_kw struct ConstantTVDomain{N<:AbstractPhase,S<:Integer,W<:Real, W2<:Real, I<:Integer, Q<:AbstractArray} <: AbstractConstantKDomain
     phase::N
-    interfaces::Array{AbstractInterface,1} = Array{AbstractInterface,1}()
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     T::W
@@ -484,7 +477,7 @@ export ParametrizedPDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
 end
-function ConstantTVDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterface,1}(),initialconds::Dict{X,E},constantspecies::Array{X2,1}=Array{String,1}(),
+function ConstantTVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse=false,sensitivity=false) where {E,X,X2, Z<:AbstractPhase,Q<:AbstractInterface,W<:Real}
     #set conditions and initialconditions
     T = 0.0
@@ -541,14 +534,13 @@ function ConstantTVDomain(;phase::Z,interfaces::Array{Q,1}=Array{EmptyInterface,
         jacobian=zeros(typeof(T),length(phase.species),length(phase.species))
     end
     rxnarray = getreactionindices(phase)
-    return ConstantTVDomain(phase,interfaces,SVector(phase.species[1].index,phase.species[end].index),constspcinds,
+    return ConstantTVDomain(phase,SVector(phase.species[1].index,phase.species[end].index),constspcinds,
         T,V,kfs,krevs,efficiencyinds,Gs,rxnarray,mu,diffs,jacobian,sensitivity,MVector(false),MVector(0.0)), y0
 end
 export ConstantTVDomain
 
 @with_kw struct ParametrizedTConstantVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
-    interfaces::Array{AbstractInterface,1} = Array{AbstractInterface,1}()
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     T::Function
@@ -559,7 +551,7 @@ export ConstantTVDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
 end
-function ParametrizedTConstantVDomain(;phase::IdealDiluteSolution,interfaces::Array{Q,1}=Array{EmptyInterface,1}(),initialconds::Dict{X,X3},constantspecies::Array{X2,1}=Array{String,1}(),
+function ParametrizedTConstantVDomain(;phase::IdealDiluteSolution,initialconds::Dict{X,X3},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {X,X2,X3,Q<:AbstractInterface}
     #set conditions and initialconditions
     T = 0.0
@@ -616,7 +608,7 @@ function ParametrizedTConstantVDomain(;phase::IdealDiluteSolution,interfaces::Ar
         jacobian=zeros(typeof(V),length(phase.species)+1,length(phase.species)+1)
     end
     rxnarray = getreactionindices(phase)
-    return ParametrizedTConstantVDomain(phase,interfaces,SVector(phase.species[1].index,phase.species[end].index),constspcinds,
+    return ParametrizedTConstantVDomain(phase,SVector(phase.species[1].index,phase.species[end].index),constspcinds,
     Tfcn,V,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0)), y0
 end
 export ParametrizedTConstantVDomain
@@ -856,20 +848,20 @@ end
 end
 export calcthermo
 
-@inline function calcdomainderivatives!(d::Q,dydt::Array{Z7,1};t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z8) where {Q<:AbstractDomain,Z11,Z10,Z9,Z8<:Real,Z7<:Real,W<:IdealGas,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real}
+@inline function calcdomainderivatives!(d::Q,dydt::Array{Z7,1},interfaces::Z12;t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z8) where {Q<:AbstractDomain,Z12,Z11,Z10,Z9,Z8<:Real,Z7<:Real,W<:IdealGas,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real}
     for ind in d.constantspeciesinds #make dydt zero for constant species
         @inbounds dydt[ind] = 0.0
     end
 end
 
-@inline function calcdomainderivatives!(d::ConstantVDomain{W,Y},dydt::Array{K,1};t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {Z11,Z10,Z9,W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real}
+@inline function calcdomainderivatives!(d::ConstantVDomain{W,Y},dydt::Array{K,1},interfaces::Z12;t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {Z12,Z11,Z10,Z9,W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real}
     @views @fastmath @inbounds dydt[d.indexes[3]] = -dot(Us,dydt[d.indexes[1]:d.indexes[2]])/(N*Cvave) #divide by V to cancel ωV to ω
     for ind in d.constantspeciesinds #make dydt zero for constant species
         @inbounds dydt[ind] = 0.0
     end
 end
 
-@inline function calcdomainderivatives!(d::ConstantPDomain{W,Y},dydt::Array{K,1};t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {Z11,Z10,Z9,W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real}
+@inline function calcdomainderivatives!(d::ConstantPDomain{W,Y},dydt::Array{K,1},interfaces::Z12;t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {Z12,Z11,Z10,Z9,W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real}
     @fastmath Cpave = Cvave+R
     @views @fastmath @inbounds dydt[d.indexes[3]] = -dot(Hs,dydt[d.indexes[1]:d.indexes[2]])/(N*Cpave) #divide by V to cancel ωV to ω
     for ind in d.constantspeciesinds #make dydt zero for constant species
@@ -877,14 +869,14 @@ end
     end
 end
 
-@inline function calcdomainderivatives!(d::ParametrizedVDomain{W,Y},dydt::Array{K,1};t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {Z11,Z10,Z9,W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real}
+@inline function calcdomainderivatives!(d::ParametrizedVDomain{W,Y},dydt::Array{K,1},interfaces::Z12;t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {Z11,Z10,Z9,W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real,Z12}
     @views @fastmath @inbounds dydt[d.indexes[3]] = (-dot(Us,dydt[d.indexes[1]:d.indexes[2]])-P*Calculus.derivative(d.V,t))/(N*Cvave) #divide by V to cancel ωV to ω
     for ind in d.constantspeciesinds #make dydt zero for constant species
         @inbounds dydt[ind] = 0.0
     end
 end
 
-@inline function calcdomainderivatives!(d::ParametrizedPDomain{W,Y},dydt::Array{K,1};t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {Z11,Z10,Z9,W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real}
+@inline function calcdomainderivatives!(d::ParametrizedPDomain{W,Y},dydt::Array{K,1},interfaces::Z12;t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {Z11,Z10,Z9,W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real,Z12}
     @fastmath Cpave = Cvave+R
     @views @fastmath @inbounds dydt[d.indexes[3]] = (-dot(Hs,dydt[d.indexes[1]:d.indexes[2]])+V*Calculus.derivative(d.P,t))/(N*Cpave) #divide by V to cancel ωV to ω
     for ind in d.constantspeciesinds #make dydt zero for constant species

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -852,12 +852,30 @@ export calcthermo
     for ind in d.constantspeciesinds #make dydt zero for constant species
         @inbounds dydt[ind] = 0.0
     end
+    for inter in interfaces
+        if isa(inter,Inlet) && d == inter.domain
+            dydt[d.indexes[1]:d.indexes[2]] .+= inter.y.*inter.F(t)
+        elseif isa(inter,Outlet) && d == inter.domain
+            dydt[d.indexes[1]:d.indexes[2]] .-= inter.F(t).*ns./N
+        end
+    end
 end
 
 @inline function calcdomainderivatives!(d::ConstantVDomain{W,Y},dydt::Array{K,1},interfaces::Z12;t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {Z12,Z11,Z10,Z9,W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real}
     @views @fastmath @inbounds dydt[d.indexes[3]] = -dot(Us,dydt[d.indexes[1]:d.indexes[2]])/(N*Cvave) #divide by V to cancel ωV to ω
     for ind in d.constantspeciesinds #make dydt zero for constant species
         @inbounds dydt[ind] = 0.0
+    end
+    for inter in interfaces
+        if isa(inter,Inlet) && d == inter.domain
+            flow = inter.F(t)
+            dydt[d.indexes[1]:d.indexes[2]] .+= inter.y.*flow
+            dydt[d.indexes[3]] += flow*(inter.H - dot(Us,ns)/N)/(N*Cvave)
+        elseif isa(inter,Outlet) && d == inter.domain
+            flow = inter.F(t)
+            dydt[d.indexes[1]:d.indexes[2]] .-= flow.*ns./N
+            dydt[d.indexes[3]] -= (P*V/N*flow)/(N*Cvave)
+        end
     end
 end
 
@@ -867,12 +885,33 @@ end
     for ind in d.constantspeciesinds #make dydt zero for constant species
         @inbounds dydt[ind] = 0.0
     end
+    for inter in interfaces
+        if isa(inter,Inlet) && d == inter.domain
+            flow = inter.F(t)
+            dydt[d.indexes[1]:d.indexes[2]] .+= inter.y.*flow
+            dydt[d.indexes[3]] += flow*(inter.H - dot(Hs,ns)/N)/(N*Cpave)
+        elseif isa(inter,Outlet) && d == inter.domain
+            flow = inter.F(t)
+            dydt[d.indexes[1]:d.indexes[2]] .-= flow.*ns./N
+        end
+    end
 end
 
 @inline function calcdomainderivatives!(d::ParametrizedVDomain{W,Y},dydt::Array{K,1},interfaces::Z12;t::Z10,T::Z4,P::Z9,Us::Array{Z,1},Hs::Array{Z11,1},V::Z2,C::Z3,ns::Array{Z5,1},N::Z6,Cvave::Z7) where {Z11,Z10,Z9,W<:IdealGas,Z7<:Real,K<:Real,Y<:Integer,Z6,Z,Z2,Z3,Z4,Z5<:Real,Z12}
     @views @fastmath @inbounds dydt[d.indexes[3]] = (-dot(Us,dydt[d.indexes[1]:d.indexes[2]])-P*Calculus.derivative(d.V,t))/(N*Cvave) #divide by V to cancel ωV to ω
     for ind in d.constantspeciesinds #make dydt zero for constant species
         @inbounds dydt[ind] = 0.0
+    end
+    for inter in interfaces
+        if isa(inter,Inlet) && d == inter.domain
+            flow = inter.F(t)
+            dydt[d.indexes[1]:d.indexes[2]] .+= inter.y.*flow
+            dydt[d.indexes[3]] += flow*(inter.H - dot(Us,ns)/N)/(N*Cvave)
+        elseif isa(inter,Outlet) && d == inter.domain
+            flow = inter.F(t)
+            dydt[d.indexes[1]:d.indexes[2]] .-= flow*ns./N
+            dydt[d.indexes[3]] -= (P*V/N*flow)/(N*Cvave)
+        end
     end
 end
 
@@ -881,6 +920,16 @@ end
     @views @fastmath @inbounds dydt[d.indexes[3]] = (-dot(Hs,dydt[d.indexes[1]:d.indexes[2]])+V*Calculus.derivative(d.P,t))/(N*Cpave) #divide by V to cancel ωV to ω
     for ind in d.constantspeciesinds #make dydt zero for constant species
         @inbounds dydt[ind] = 0.0
+    end
+    for inter in interfaces
+        if isa(inter,Inlet) && d == inter.domain
+            flow = inter.F(t)
+            dydt[d.indexes[1]:d.indexes[2]] .+= inter.y.*flow
+            dydt[d.indexes[3]] += flow*(inter.H - dot(Hs,ns)/N)/(N*Cpave)
+        elseif isa(inter,Outlet) && d == inter.domain
+            flow = inter.F(t)
+            dydt[d.indexes[1]:d.indexes[2]] .-= flow.*ns./N
+        end
     end
 end
 export calcdomainderivatives!

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -19,25 +19,28 @@ export EmptyInterface
 end
 export IdealGasCatalystInterface
 
-struct Inlet{Q<:Real,V<:AbstractArray,U<:Real,X<:Real} <: AbstractBoundaryInterface
-    F::V
+struct Inlet{Q<:Real,S,V<:AbstractArray,U<:Real,X<:Real} <: AbstractBoundaryInterface
+    domain::S
+    y::V
+    F::Function
     T::U
     P::X
-    dUdt::Q
+    H::Q
 end
 
-function Inlet(phase::V,conddict::Dict{String,X},F::B) where {V<:AbstractPhase,X<:Real,B<:Real}
-    y = makespcsvector(phase,conddict)
+function Inlet(domain::V,conddict::Dict{String,X},F::Function) where {V,X<:Real,B<:Real}
+    y = makespcsvector(domain.phase,conddict)
     T = conddict["T"]
     P = conddict["P"]
-    Fout = F.*y./sum(y)
-    dUdt = dot(getEnthalpy.(getfield.(ph.species,:thermo),T),Fout)
-    return Inlet(Fout,T,P,dUdt)
+    yout = y./sum(y)
+    H = dot(getEnthalpy.(getfield.(domain.phase.species,:thermo),T),yout)
+    return Inlet(domain,yout,F,T,P,H)
 end
 
 export Inlet
 
-struct Outlet{V<:Real} <: AbstractBoundaryInterface
-    F::V
+struct Outlet{V} <: AbstractBoundaryInterface
+    domain::V
+    F::Function
 end
 export Outlet

--- a/src/PhaseState.jl
+++ b/src/PhaseState.jl
@@ -40,6 +40,7 @@ function makespcsvector(phase,spcdict)
             y0[ind] = val
         end
     end
+    return y0
 end
 
 export makespcsvector

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -10,8 +10,8 @@ struct Reactor{D<:AbstractDomain} <: AbstractReactor
     ode::ODEProblem
 end
 
-function Reactor(domain::T,y0::Array{W,1},tspan::Tuple) where {T<:AbstractDomain,W<:Real}
-    dydt(y::Array{T,1},p::V,t::Q) where {T<:Real,Q<:Real,V} = dydtreactor!(y,t,domain)
+function Reactor(domain::T,y0::Array{W,1},tspan::Tuple,interfaces::Z=[]) where {T<:AbstractDomain,W<:Real,Z}
+    dydt(y::Array{T,1},p::V,t::Q) where {T<:Real,Q<:Real,V} = dydtreactor!(y,t,domain,interfaces)
     ode = ODEProblem(dydt,y0,tspan)
     return Reactor(domain,ode)
 end
@@ -76,7 +76,7 @@ export getrate
 end
 export addreactionratecontributions!
 
-@inline function dydtreactor!(y::Array{U,1},t::Z,domain::Q;sensitivity::Bool=true) where {Z<:Real,U<:Real,J<:Integer,Q<:AbstractDomain}
+@inline function dydtreactor!(y::Array{U,1},t::Z,domain::Q,interfaces::B;sensitivity::Bool=true) where {B,Z<:Real,U<:Real,J<:Integer,Q<:AbstractDomain}
     dydt = zeros(U,length(y))
     if sensitivity #if sensitivity isn't explicitly set to false set it to domain.sensitivity
         sensitivity = domain.sensitivity
@@ -89,7 +89,7 @@ export addreactionratecontributions!
     else
         wV = Array{U,1}()
     end
-    calcdomainderivatives!(domain,dydt;t=t,T=T,P=P,Us=Us,Hs=Hs,V=V,C=C,ns=ns,N=N,Cvave=Cvave)
+    calcdomainderivatives!(domain,dydt,interfaces;t=t,T=T,P=P,Us=Us,Hs=Hs,V=V,C=C,ns=ns,N=N,Cvave=Cvave)
     if sensitivity
         Nspcs = length(cs)
         Nrxns = length(domain.phase.reactions)


### PR DESCRIPTION
Add Inlets and Outlets interfaces to RMS. This enables CSTR-like, semi-batch and draining reactor type simulations.  