### PR TITLE
Clean the installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,5 @@ Flux diagrams with molecular images (if molecular information is provided).
 Handy plotting and other solution analysis tools.  
 Easy to add new features.  
 
-## Installation
 
-RMS currently has dependencies that are only available in python 2.  So currently in order to use RMS it is necessary for your PyCall to reference a python 2 installation.  
-
-This can be done with PyCall uninstalled:  
-```
-using Pkg
-ENV["PYTHON"] = "absolute path to python 2 executable ex:  ~/anaconda2/envs/conda_jl/bin/python"
-ENV["CONDA_JL_HOME"] = "absolute path to the python install ex:  ~/anaconda2/envs/conda_jl"
-Pkg.add("PyCall")
-Pkg.build("PyCall")
-```
-
-Once this is done RMS can be installed with:
-```
-using Pkg
-Pkg.add("ReactionMechanismSimulator")
-Pkg.build("ReactionMechanismSimulator")
-
-using ReactionMechanismSimulator
-```
-
-Detailed instructions and documentation are currently available in the <a href="https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/wiki">wiki</a>.
+Detailed <a href="https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/wiki/RMS-Installation">installation instructions</a>. and documentation are currently available in the <a href="https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/wiki">wiki</a>.


### PR DESCRIPTION
[HOLD MERGING] waiting for the trial by Kevin.

I saw your modification in pyrms, where you removed `PyCall` related things. So we don't need to worry about PyCall anymore?

I created a new wiki page about the RMS installation. I personally followed this guide to help people install RMS. The original instruction in README is very confusing at this moment, so I just removed it. Please let me know your thoughts and any suggestions about the wiki page. Thanks.