### PR TITLE
Remove unconnected nodes for single time flux diagrams

### DIFF
--- a/src/fluxdiagrams.jl
+++ b/src/fluxdiagrams.jl
@@ -295,8 +295,8 @@ function makefluxdiagrams(bsol,ts;centralspecieslist=Array{String,1}(),superimpo
         end
 
         slope = -maximumedgepenwidth / log10(speciesratetolerance)
-        minspeciesrate = Inf
         maxspcrate = -Inf
+        minspeciesrate = Inf
         for index in 1:length(edges)
             reactantindex,productindex = edges[index]
             sprate = abs(speciesrates[reactantindex,productindex,t])
@@ -307,6 +307,7 @@ function makefluxdiagrams(bsol,ts;centralspecieslist=Array{String,1}(),superimpo
                 maxspcrate = sprate
             end
         end
+        minspeciesrate = max(minspeciesrate,maxspcrate*speciesratetolerance)
         
         for index in 1:length(edges)
             reactantindex,productindex = edges[index]


### PR DESCRIPTION
added removeunconnectednodes option to getfluxdiagram and makefluxdiagrams
default on for getfluxdiagram default off for makefluxdiagrams

removes species that aren't connected by edges by default if only making diagram at one time point. 