### PR TITLE
Enable Manipulation of Parameters

### DIFF
--- a/src/Calculators/Rate.jl
+++ b/src/Calculators/Rate.jl
@@ -183,6 +183,20 @@ export getredpress
     end
     return @fastmath 10.0^k
 end
-
-
 export Chebyshev
+
+@inline function getkineticstype(kin::B) where {B<:AbstractRate}
+    return string(typeof(kin).name)
+end
+
+@inline function getkineticstype(kin::PdepArrhenius)
+    if occursin("AbstractRate", string(typeof(kin).parameters[3])) || occursin("MultiArrhenius", string(typeof(kin).parameters[3])) #no optimized function so don't put kinetics name first
+        return ("AbstRate",string(typeof(kin).name),trunc.(kin.Ps,digits=3))
+    else #optimized function available so put kinetics name first
+        return (string(typeof(kin).name),trunc.(kin.Ps,digits=3))
+    end
+end
+
+@inline function getkineticstype(kin::Chebyshev)
+    return (string(typeof(kin).name),kin.Tmin,kin.Tmax,kin.Pmin,kin.Pmax,size(kin.coefs)) #different opt functions, but always can do
+end

--- a/src/Calculators/Ratevec.jl
+++ b/src/Calculators/Ratevec.jl
@@ -23,4 +23,76 @@ end
 @inline (arr::Arrheniusvec)(T::Q;P::N=0.0,C::S=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath @inbounds arr.A.*exp.(arr.n.*log(T).-arr.Ea.*(1.0/(R*T)))::Array{Q,1}
 export Arrheniusvec
 
+@with_kw struct Chebyshevvec{T<:AbstractArray,Q<:Real,S<:Real,V<:Real,B<:Real} <: AbstractRate
+    coefs::T
+    Tmin::Q
+    Tmax::S
+    Pmin::V
+    Pmax::B
+end
 
+function Chebyshevvec(chevs::T) where {T<:AbstractArray}
+    coefs = zeros(length(chevs),size(chevs[1].coefs)[1],size(chevs[1].coefs)[2])
+    for k in 1:size(chevs[1].coefs)[2]
+        for j in 1:size(chevs[1].coefs)[1]
+            for i in 1:length(chevs)
+                coefs[i,j,k] = chevs[i].coefs[j,k]
+            end
+        end
+    end
+    return Chebyshevvec(coefs=coefs,Tmin=chevs[1].Tmin,Tmax=chevs[1].Tmax,Pmin=chevs[1].Pmin,Pmax=chevs[1].Pmax)
+end
+export Chebyshevvec
+
+@inline function evalChebyshevPolynomial(ch::Chebyshevvec,n::N,x::Q) where {N<:Integer,Q<:Real}
+    """
+    evaluate the nth order Chebyshev Polynomial at x
+    """
+    if n==0
+        return 1.0
+    elseif n == 1
+        return x
+    else
+        T = 0.0
+        T0 = 1.0
+        T1 = x
+        for i in 1:(n-1)
+            @fastmath T = 2*x*T1-T0
+            T0 = T1
+            T1 = T
+        end
+        return T
+    end
+end
+export evalChebyshevPolynomial
+
+@inline function getredtemp(ch::Chebyshevvec,T::N) where {N<:Real}
+    """
+    return a reduced temperature corresponding to the given tempeprature
+    for the Chebyshev polynomial, maps the inverse of temperautre onto [-1,1]
+    """
+    return @fastmath (2.0/T-1.0/ch.Tmin-1.0/ch.Tmax)/(1.0/ch.Tmax-1.0/ch.Tmin)
+end
+export getredtemp
+
+@inline function getredpress(ch::Chebyshevvec,P::N) where {N<:Real}
+    """
+    return a reduced pressure corresponding to the given temperature
+    for the Chebyshev polynomial maps the logarithm of pressure onto [-1,1]
+    """
+    return @fastmath (2.0*log10(P)-log10(ch.Pmin)-log10(ch.Pmax))/(log10(ch.Pmax)-log10(ch.Pmin))
+end
+export getredpress
+
+@inline function (ch::Chebyshevvec)(;T::N,P::Q=0.0,C::B=0.0) where {N<:Real,B<:Real,Q<:Real}
+    k = zeros(size(ch.coefs)[1])
+    Tred = getredtemp(ch,T)
+    Pred = getredpress(ch,P)
+    klen,Tlen,Plen = size(ch.coefs)
+    @simd for j = 1:Plen
+        @simd for i = 1:Tlen
+            @fastmath @inbounds k .+= ch.coefs[:,i,j].*(evalChebyshevPolynomial(ch,i-1,Tred)*evalChebyshevPolynomial(ch,j-1,Pred))
+        end
+    end
+    return @fastmath 10.0.^k
+end

--- a/src/Calculators/Ratevec.jl
+++ b/src/Calculators/Ratevec.jl
@@ -1,0 +1,26 @@
+using Parameters
+
+abstract type AbstractRatevec end
+export AbstractRatevec
+
+@with_kw struct Arrheniusvec{N<:Array,K<:Array,Q<:Array} <: AbstractRatevec
+        A::N
+        n::K
+        Ea::Q
+end
+function Arrheniusvec(arrs::T) where {T<:AbstractArray}
+    A = zeros(length(arrs)) 
+    n = zeros(length(arrs)) 
+    Ea = zeros(length(arrs))
+    for (i,aval) in enumerate(arrs)
+        A[i] = aval.A
+        n[i] = aval.n
+        Ea[i] = aval.Ea
+    end
+    return Arrheniusvec(A=A,n=n,Ea=Ea)
+end
+@inline (arr::Arrheniusvec)(;T::Q,P::N=0.0,C::S=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath @inbounds arr.A.*exp.(arr.n.*log(T).-arr.Ea.*(1.0/(R*T)))::Array{Q,1}
+@inline (arr::Arrheniusvec)(T::Q;P::N=0.0,C::S=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath @inbounds arr.A.*exp.(arr.n.*log(T).-arr.Ea.*(1.0/(R*T)))::Array{Q,1}
+export Arrheniusvec
+
+

--- a/src/Calculators/Ratevec.jl
+++ b/src/Calculators/Ratevec.jl
@@ -85,7 +85,7 @@ end
 export getredpress
 
 @inline function (ch::Chebyshevvec)(;T::N,P::Q=0.0,C::B=0.0) where {N<:Real,B<:Real,Q<:Real}
-    k = zeros(size(ch.coefs)[1])
+    k = zeros(N,size(ch.coefs)[1])
     Tred = getredtemp(ch,T)
     Pred = getredpress(ch,P)
     klen,Tlen,Plen = size(ch.coefs)

--- a/src/Calculators/Thermo.jl
+++ b/src/Calculators/Thermo.jl
@@ -14,7 +14,7 @@ end
 end
 export NASApolynomial
 
-@inline function calcHSCpdless(poly::NASApolynomial,T::Float64)
+@inline function calcHSCpdless(poly::NASApolynomial,T::X) where {X<:Real}
     if length(poly.coefs) != 7
         Tpoly0 = T
         Tpoly1 = T*T

--- a/src/Calculators/Thermovec.jl
+++ b/src/Calculators/Thermovec.jl
@@ -1,0 +1,124 @@
+using Parameters
+
+abstract type AbstractThermovec end
+export AbstractThermovec
+
+include("Thermo.jl")
+
+@with_kw struct NASApolynomialvec <: AbstractThermo
+    coefs::Array{Float64,2}
+    Tmin::Float64
+    Tmax::Float64
+end
+
+@with_kw struct NASAvec{T<:AbstractThermoUncertainty} <: AbstractThermo
+    polys::Array{NASApolynomialvec,1}
+    unc::T = EmptyThermoUncertainty()
+end
+function NASAvec(nasas::B) where {B<:Array}
+    Tmin = nasas[1].polys[1].Tmin
+    Tmax = nasas[1].polys[end].Tmax
+    Ts = Array{Float64,1}()
+    for nasa in nasas
+        for (i,poly) in enumerate(nasa.polys)
+            if i == 1 && poly.Tmin > Tmin
+                Tmin = poly.Tmin
+                push!(Ts,poly.Tmax)
+            elseif i == length(nasa.polys) && nasa.polys[end].Tmax < Tmax
+                Tmax = poly.Tmax
+                push!(Ts,poly.Tmin)
+            else
+                push!(Ts,poly.Tmin)
+                push!(Ts,poly.Tmax)
+            end
+        end
+    end
+    Ts = [Tmin,Ts...,Tmax]
+    Ts = unique(sort(Ts))
+    polyvecs = Array{NASApolynomialvec,1}()
+    for i in 1:length(Ts)-1
+        T = (Ts[i]+Ts[i+1])/2.0
+        if all([size(x.coefs)[1] == 7 for x in polyvecs])
+            polyvec = zeros(7,length(nasas))
+        else 
+            polyvec = zeros(9,length(nasas))
+        end
+        for (j,nasa) in enumerate(nasas)
+            nasapoly = selectPoly(nasa,T)
+            if size(polyvec)[1] == 9 && size(nasapoly.coefs)[1] == 7
+                coefs = zeros(9)
+                coefs[3:end] = nasapoly.coefs
+                polyvec[:,j] = coefs
+            else 
+                polyvec[:,j] = nasapoly.coefs
+            end
+        end
+        nasapvec = NASApolynomialvec(polyvec,Ts[i],Ts[i+1])
+        push!(polyvecs,nasapvec)
+    end
+    
+    return NASAvec(polys=polyvecs) 
+        
+end
+@inline function selectPoly(nasa::NASAvec,T::N) where {N<:Real}
+    """
+    retrieve the nasa polynomial corresponding to the T range
+    """
+    for p in nasa.polys
+        if T<=p.Tmax
+            return p
+        end
+    end
+    return nasa.polys[end]
+end
+export selectPoly
+
+@inline function calcHSCpdless(poly::NASApolynomialvec,T::Float64)
+    if size(poly.coefs)[1] != 7
+        Tpoly0 = T
+        Tpoly1 = T*T
+        Tpoly2 = Tpoly1*T
+        Tpoly3 = Tpoly2*T
+        Tpoly4 = 1.0/T
+        Tpoly5 = Tpoly4*Tpoly4
+        Tpoly6 = log(T)
+
+        ct0 = poly.coefs[1,:].*Tpoly5
+        ct1 = poly.coefs[2,:].*Tpoly4
+        ct2 = poly.coefs[3,:]
+        ct3 = poly.coefs[4,:].*Tpoly0
+        ct4 = poly.coefs[5,:].*Tpoly1
+        ct5 = poly.coefs[6,:].*Tpoly2
+        ct6 = poly.coefs[7,:].*Tpoly3
+
+        cpdivR = ct0 .+ ct1 .+ ct2 .+ ct3 .+ ct4 .+ ct5 .+ ct6
+        hdivRT = -ct0.+Tpoly6.*ct1.+ct2.+0.5.*ct3.+0.33333333333.*ct4.+0.25.*ct5+0.2.*ct6+poly.coefs[8,:].*Tpoly4
+        sdivR = -0.5.*ct0 .- ct1 .+ Tpoly6.*ct2 .+ ct3 .+ 0.5.*ct4 .+ 0.33333333333.*ct5 .+ 0.25*ct6 .+ poly.coefs[9,:]
+    else
+        Tpoly0 = T
+        Tpoly1 = T*T
+        Tpoly2 = Tpoly1*T
+        Tpoly3 = Tpoly2*T
+        Tpoly4 = 1.0/T
+        #Tpoly5 = Tpoly4*Tpoly4
+        Tpoly6 = log(T)
+
+        #ct0 = 0.0
+        #ct1 = 0.0
+        ct2 = poly.coefs[1,:]
+        ct3 = poly.coefs[2,:].*Tpoly0
+        ct4 = poly.coefs[3,:].*Tpoly1
+        ct5 = poly.coefs[4,:].*Tpoly2
+        ct6 = poly.coefs[5,:].*Tpoly3
+
+        cpdivR = ct2 .+ ct3 .+ ct4 .+ ct5 .+ ct6
+        hdivRT = ct2.+0.5.*ct3.+0.33333333333.*ct4.+0.25.*ct5.+0.2.*ct6.+poly.coefs[6,:].*Tpoly4
+        sdivR = Tpoly6.*ct2 .+ ct3 .+ 0.5.*ct4 .+ 0.33333333333.*ct5 .+ 0.25.*ct6 .+ poly.coefs[7,:]
+    end
+    return (cpdivR,hdivRT,sdivR)
+end
+
+@inline function calcHSCpdless(nasavec::NASAvec,T::Float64)
+    poly = selectPoly(nasavec,T)
+    return calcHSCpdless(poly,T)
+end

--- a/src/Calculators/Thermovec.jl
+++ b/src/Calculators/Thermovec.jl
@@ -73,7 +73,7 @@ end
 end
 export selectPoly
 
-@inline function calcHSCpdless(poly::NASApolynomialvec,T::Float64)
+@inline function calcHSCpdless(poly::NASApolynomialvec,T::X) where {X<:Real}
     if size(poly.coefs)[1] != 7
         Tpoly0 = T
         Tpoly1 = T*T
@@ -118,7 +118,7 @@ export selectPoly
     return (cpdivR,hdivRT,sdivR)
 end
 
-@inline function calcHSCpdless(nasavec::NASAvec,T::Float64)
+@inline function calcHSCpdless(nasavec::NASAvec,T::X) where {X<:Real}
     poly = selectPoly(nasavec,T)
     return calcHSCpdless(poly,T)
 end

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -663,12 +663,10 @@ end
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
     Cvave = 0.0
-    @simd for i = 1:length(d.phase.species)
-        @inbounds cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.species[i].thermo,T)
-        @fastmath @inbounds Gs[i] = (hdivRT-sdivR)*R*T
-        @fastmath @inbounds Us[i] = (hdivRT-1.0)*R*T
-        @fastmath @inbounds Cvave += cpdivR*ns[i]
-    end
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Us = (hdivRT.-1.0)*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
     @fastmath Cvave *= R/N
     @fastmath Cvave -= R
     if d.phase.diffusionlimited
@@ -693,13 +691,10 @@ end
     C = N/V
     Gs = zeros(length(d.phase.species))
     Hs = zeros(length(d.phase.species))
-    Cvave = 0.0
-    @simd for i = 1:length(d.phase.species)
-        @inbounds cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.species[i].thermo,T)
-        @fastmath @inbounds Hs[i] = hdivRT*R*T
-        @fastmath @inbounds Gs[i] = (hdivRT-sdivR)*R*T
-        @fastmath @inbounds Cvave += cpdivR*ns[i]
-    end
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Hs = hdivRT.*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
     @fastmath Cvave *= R/N
     @fastmath Cvave -= R
     if d.phase.diffusionlimited
@@ -725,13 +720,10 @@ end
     P = C*R*T
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
-    Cvave = 0.0
-    @simd for i = 1:length(d.phase.species)
-        @inbounds cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.species[i].thermo,T)
-        @fastmath @inbounds Gs[i] = (hdivRT-sdivR)*R*T
-        @fastmath @inbounds Us[i] = (hdivRT-1.0)*R*T
-        @fastmath @inbounds Cvave += cpdivR*ns[i]
-    end
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Us = (hdivRT.-1.0)*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
     @fastmath Cvave *= R/N
     @fastmath Cvave -= R
     if d.phase.diffusionlimited
@@ -757,13 +749,10 @@ end
     C = N/V
     Gs = zeros(length(d.phase.species))
     Hs = zeros(length(d.phase.species))
-    Cvave = 0.0
-    @simd for i = 1:length(d.phase.species)
-        @inbounds cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.species[i].thermo,T)
-        @fastmath @inbounds Gs[i] = (hdivRT-sdivR)*R*T
-        @fastmath @inbounds Hs[i] = hdivRT*R*T
-        @fastmath @inbounds Cvave += cpdivR*ns[i]
-    end
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Hs = hdivRT.*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
     @fastmath Cvave *= R/N
     @fastmath Cvave -= R
     if d.phase.diffusionlimited
@@ -789,10 +778,8 @@ end
     P = C*R*T
     Gs = zeros(length(d.phase.species))
     mu = d.phase.solvent.mu(T)
-    for i = 1:length(d.phase.species)
-        @inbounds cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.species[i].thermo,T)
-        @fastmath @inbounds Gs[i] = (hdivRT-sdivR)*R*T
-    end
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
     if d.phase.diffusionlimited
         diffs = [x(T=T,mu=mu,P=P) for x in getfield.(d.phase.species,:diffusion)]
     else
@@ -818,11 +805,9 @@ end
     P = C*R*T
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
-    Cvave = 0.0
-    @simd for i = 1:length(d.phase.species)
-        @inbounds cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.species[i].thermo,T)
-        @fastmath @inbounds Gs[i] = (hdivRT-sdivR)*R*T
-    end
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
     @fastmath Cvave *= R/N
     @fastmath Cvave -= R
     if d.phase.diffusionlimited

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -714,9 +714,8 @@ end
     end
     return ns,cs,d.T,d.P,V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
 end
-end
 
-@inline function calcthermo(d::ConstantVDomain{W,Y},y::J,t::Q) where {W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+@inline function calcthermo(d::ConstantVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
     if t != d.t[1]
         d.t[1] = t
         d.jacuptodate[1] = false
@@ -737,15 +736,75 @@ end
     @fastmath Cvave *= R/N
     @fastmath Cvave -= R
     if d.phase.diffusionlimited
-        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
     else
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=d.V)
-    return ns,cs,T,P,d.V,C,N,0.0,kfs,krevs,[],Us,Gs,diffs,Cvave
+    return ns,cs,T,P,d.V,C,N,0.0,kfs,krevs,Array{Float64,1}(),Us,Gs,diffs,Cvave
 end
 
-@inline function calcthermo(d::ConstantPDomain{W,Y},y::J,t::Q) where {W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+@inline function calcthermo(d::ConstantVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    ns = y[d.indexes[1]:d.indexes[2]]
+    T = y[d.indexes[3]]
+    N = sum(ns)
+    cs = ns./d.V
+    C = N/d.V
+    P = C*R*T
+    Gs = zeros(length(d.phase.species))
+    Us = zeros(length(d.phase.species))
+    Cvave = 0.0
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @views @fastmath hdivRT .+= p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Us = (hdivRT.-1.0)*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
+    @fastmath Cvave *= R/N
+    @fastmath Cvave -= R
+    if d.phase.diffusionlimited
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=d.V)
+    return @views @fastmath ns,cs,T,P,d.V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave
+end
+
+@inline function calcthermo(d::ConstantVDomain{W,Y},y::J,t::Q,p::Array{W2,1}=DiffEqBase.NullParameters()) where {W2<:ForwardDiff.Dual,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    ns = y[d.indexes[1]:d.indexes[2]]
+    T = y[d.indexes[3]]
+    N = sum(ns)
+    cs = ns./d.V
+    C = N/d.V
+    P = C*R*T
+    Gs = zeros(length(d.phase.species))
+    Us = zeros(length(d.phase.species))
+    Cvave = 0.0
+    cpdivR,hdivRT1,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath @views hdivRT = hdivRT1 .+ p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Us = (hdivRT.-1.0)*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
+    @fastmath Cvave *= R/N
+    @fastmath Cvave -= R
+    if d.phase.diffusionlimited
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=d.V)
+    return @views @fastmath ns,cs,T,P,d.V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave
+end
+
+@inline function calcthermo(d::ConstantPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
     if t != d.t[1]
         d.t[1] = t
         d.jacuptodate[1] = false
@@ -765,15 +824,77 @@ end
     @fastmath Cvave *= R/N
     @fastmath Cvave -= R
     if d.phase.diffusionlimited
-        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=d.P)
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=d.P)::Array{typeof(T),1}
     else
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=d.P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return ns,cs,T,d.P,V,C,N,0.0,kfs,krevs,Hs,[],Gs,diffs,Cvave
+    return ns,cs,T,d.P,V,C,N,0.0,kfs,krevs,Hs,Array{Float64,1}(),Gs,diffs,Cvave
 end
 
-@inline function calcthermo(d::ParametrizedVDomain{W,Y},y::J,t::Q) where {W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+@inline function calcthermo(d::ConstantPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    ns = y[d.indexes[1]:d.indexes[2]]
+    T = y[d.indexes[3]]
+    N = sum(ns)
+    V = N*R*T/d.P
+    cs = ns./V
+    C = N/V
+    Gs = zeros(length(d.phase.species))
+    Hs = zeros(length(d.phase.species))
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath @views hdivRT .+= p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Hs = hdivRT.*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
+    @fastmath Cvave *= R/N
+    @fastmath Cvave -= R
+    if d.phase.diffusionlimited
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=d.P)::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=d.P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
+    if p != DiffEqBase.NullParameters()
+        return @views @fastmath ns,cs,T,d.P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave
+    else
+        return ns,cs,T,d.P,V,C,N,0.0,kfs,krevs,Hs,Array{Float64,1}(),Gs,diffs,Cvave
+    end
+end
+
+@inline function calcthermo(d::ConstantPDomain{W,Y},y::J,t::Q,p::Array{W2,1}=DiffEqBase.NullParameters()) where {W2<:ForwardDiff.Dual,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    ns = y[d.indexes[1]:d.indexes[2]]
+    T = y[d.indexes[3]]
+    N = sum(ns)
+    V = N*R*T/d.P
+    cs = ns./V
+    C = N/V
+    Gs = zeros(length(d.phase.species))
+    Hs = zeros(length(d.phase.species))
+    cpdivR,hdivRT1,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath @views hdivRT = hdivRT1 .+ p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Hs = hdivRT.*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
+    @fastmath Cvave *= R/N
+    @fastmath Cvave -= R
+    if d.phase.diffusionlimited
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=d.P)::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=d.P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
+    return @views @fastmath ns,cs,T,d.P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave
+end
+
+@inline function calcthermo(d::ParametrizedVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
     if t != d.t[1]
         d.t[1] = t
         d.jacuptodate[1] = false
@@ -794,15 +915,75 @@ end
     @fastmath Cvave *= R/N
     @fastmath Cvave -= R
     if d.phase.diffusionlimited
-        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
     else
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,[],Us,Gs,diffs,Cvave
+    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,Array{Float64,1}(),Us,Gs,diffs,Cvave
 end
 
-@inline function calcthermo(d::ParametrizedPDomain{W,Y},y::J,t::Q) where {W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+@inline function calcthermo(d::ParametrizedVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    V = d.V(t)
+    ns = y[d.indexes[1]:d.indexes[2]]
+    T = y[d.indexes[3]]
+    N = sum(ns)
+    cs = ns./V
+    C = N/V
+    P = C*R*T
+    Gs = zeros(length(d.phase.species))
+    Us = zeros(length(d.phase.species))
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath @views hdivRT .+= p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Us = (hdivRT.-1.0)*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
+    @fastmath Cvave *= R/N
+    @fastmath Cvave -= R
+    if d.phase.diffusionlimited
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave
+end
+
+@inline function calcthermo(d::ParametrizedVDomain{W,Y},y::J,t::Q,p::Array{W2,1}=DiffEqBase.NullParameters()) where {W2<:ForwardDiff.Dual,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    V = d.V(t)
+    ns = y[d.indexes[1]:d.indexes[2]]
+    T = y[d.indexes[3]]
+    N = sum(ns)
+    cs = ns./V
+    C = N/V
+    P = C*R*T
+    Gs = zeros(length(d.phase.species))
+    Us = zeros(length(d.phase.species))
+    cpdivR,hdivRT1,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath @views hdivRT = hdivRT1 .+ p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Us = (hdivRT.-1.0)*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
+    @fastmath Cvave *= R/N
+    @fastmath Cvave -= R
+    if d.phase.diffusionlimited
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave
+end
+
+@inline function calcthermo(d::ParametrizedPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
     if t != d.t[1]
         d.t[1] = t
         d.jacuptodate[1] = false
@@ -823,15 +1004,74 @@ end
     @fastmath Cvave *= R/N
     @fastmath Cvave -= R
     if d.phase.diffusionlimited
-        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
     else
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,Hs,[],Gs,diffs,Cvave
+    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,Hs,Array{Float64,1}(),Gs,diffs,Cvave
 end
 
-@inline function calcthermo(d::ParametrizedTConstantVDomain{W,Y},y::J,t::Q) where {W<:IdealDiluteSolution,Y<:Integer,J<:AbstractArray,Q<:Real}
+@inline function calcthermo(d::ParametrizedPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    P = d.P(t)
+    ns = y[d.indexes[1]:d.indexes[2]]
+    T = y[d.indexes[3]]
+    N = sum(ns)
+    V = N*R*T/P
+    cs = ns./V
+    C = N/V
+    Gs = zeros(length(d.phase.species))
+    Hs = zeros(length(d.phase.species))
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath @views hdivRT .+= p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Hs = hdivRT.*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
+    @fastmath Cvave *= R/N
+    @fastmath Cvave -= R
+    if d.phase.diffusionlimited
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave
+end
+@inline function calcthermo(d::ParametrizedPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:ForwardDiff.Dual,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    P = d.P(t)
+    ns = y[d.indexes[1]:d.indexes[2]]
+    T = y[d.indexes[3]]
+    N = sum(ns)
+    V = N*R*T/P
+    cs = ns./V
+    C = N/V
+    Gs = zeros(length(d.phase.species))
+    Hs = zeros(length(d.phase.species))
+    cpdivR,hdivRT1,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath @views hdivRT = hdivRT1 .+ p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Hs = hdivRT.*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
+    @fastmath Cvave *= R/N
+    @fastmath Cvave -= R
+    if d.phase.diffusionlimited
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave
+end
+
+@inline function calcthermo(d::ParametrizedTConstantVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealDiluteSolution,Y<:Integer,J<:AbstractArray,Q<:Real}
     if t != d.t[1]
         d.t[1] = t
         d.jacuptodate[1] = false
@@ -848,15 +1088,67 @@ end
     cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
     @fastmath Gs = (hdivRT.-sdivR)*(R*T)
     if d.phase.diffusionlimited
-        diffs = [x(T=T,mu=mu,P=P) for x in getfield.(d.phase.species,:diffusion)]
+        diffs = [x(T=T,mu=mu,P=P) for x in getfield.(d.phase.species,:diffusion)]::Array{typeof(T),1}
     else
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,[],[],Gs,diffs,0.0
+    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
 end
 
-@inline function calcthermo(d::ParametrizedTPDomain{W,Y},y::J,t::Q) where {W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+@inline function calcthermo(d::ParametrizedTConstantVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealDiluteSolution,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    V = d.V
+    T = d.T(t)
+    ns = y[d.indexes[1]:d.indexes[2]]
+    N = sum(ns)
+    cs = ns./V
+    C = N/V
+    P = C*R*T
+    Gs = zeros(length(d.phase.species))
+    mu = d.phase.solvent.mu(T)
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath @views hdivRT .+= p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    if d.phase.diffusionlimited
+        diffs = [x(T=T,mu=mu,P=P) for x in getfield.(d.phase.species,:diffusion)]::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
+end
+
+@inline function calcthermo(d::ParametrizedTConstantVDomain{W,Y},y::J,t::Q,p::Array{W2,1}=DiffEqBase.NullParameters()) where {W2<:ForwardDiff.Dual,W<:IdealDiluteSolution,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    V = d.V
+    T = d.T(t)
+    ns = y[d.indexes[1]:d.indexes[2]]
+    N = sum(ns)
+    cs = ns./V
+    C = N/V
+    P = C*R*T
+    Gs = zeros(length(d.phase.species))
+    mu = d.phase.solvent.mu(T)
+    cpdivR,hdivRT1,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath @views hdivRT = hdivRT1 .+ p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    if d.phase.diffusionlimited
+        diffs = [x(T=T,mu=mu,P=P) for x in getfield.(d.phase.species,:diffusion)]::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
+end
+
+@inline function calcthermo(d::ParametrizedTPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
     if t != d.t[1]
         d.t[1] = t
         d.jacuptodate[1] = false
@@ -878,12 +1170,74 @@ end
     @fastmath Cvave *= R/N
     @fastmath Cvave -= R
     if d.phase.diffusionlimited
-        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
     else
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,[],[],Gs,diffs,0.0
+    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
+end
+
+@inline function calcthermo(d::ParametrizedTPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    T = d.T(t)
+    @assert T < 10000.0
+    P = d.P(t)
+    ns = y[d.indexes[1]:d.indexes[2]]
+    N = sum(ns)
+    V = N*T*R/P
+    cs = ns./V
+    C = N/V
+    P = C*R*T
+    Gs = zeros(length(d.phase.species))
+    Us = zeros(length(d.phase.species))
+    cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath @views hdivRT .+= p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
+    @fastmath Cvave *= R/N
+    @fastmath Cvave -= R
+    if d.phase.diffusionlimited
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
+end
+
+@inline function calcthermo(d::ParametrizedTPDomain{W,Y},y::J,t::Q,p::Array{W2,1}=DiffEqBase.NullParameters()) where {W2<:ForwardDiff.Dual,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
+    if t != d.t[1]
+        d.t[1] = t
+        d.jacuptodate[1] = false
+    end
+    T = d.T(t)
+    @assert T < 10000.0
+    P = d.P(t)
+    ns = y[d.indexes[1]:d.indexes[2]]
+    N = sum(ns)
+    V = N*T*R/P
+    cs = ns./V
+    C = N/V
+    P = C*R*T
+    Gs = zeros(length(d.phase.species))
+    Us = zeros(length(d.phase.species))
+    cpdivR,hdivRT1,sdivR = calcHSCpdless(d.phase.vecthermo,T)
+    @fastmath @views hdivRT = hdivRT1 .+ p[1:length(d.phase.species)]./(R*T)
+    @fastmath Gs = (hdivRT.-sdivR)*(R*T)
+    @fastmath Cvave = dot(cpdivR,ns)
+    @fastmath Cvave *= R/N
+    @fastmath Cvave -= R
+    if d.phase.diffusionlimited
+        diffs = getfield.(d.phase.species,:diffusion)(T=T,mu=mu,P=P)::Array{typeof(T),1}
+    else
+        diffs = Array{Float64,1}()
+    end
+    kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
 end
 
 @inline function calcthermo(d::ConstantTVDomain{W,Y},y::J,t::Q,p::Q2=DiffEqBase.NullParameters()) where {Q2<:DiffEqBase.NullParameters,W<:IdealDiluteSolution,Y<:Integer,J<:AbstractArray,Q<:Real}

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -3,6 +3,8 @@ using LinearAlgebra
 using StaticArrays
 using Dierckx
 using Calculus
+using DiffEqBase
+using ForwardDiff
 
 abstract type AbstractDomain end
 export AbstractDomain

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -466,7 +466,7 @@ function ParametrizedPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies
 end
 export ParametrizedPDomain
 
-@with_kw struct ConstantTVDomain{N<:AbstractPhase,S<:Integer,W<:Real, W2<:Real, I<:Integer, Q<:AbstractArray} <: AbstractConstantKDomain
+@with_kw mutable struct ConstantTVDomain{N<:AbstractPhase,S<:Integer,W<:Real, W2<:Real, I<:Integer, Q<:AbstractArray} <: AbstractConstantKDomain
     phase::N
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}

--- a/src/Parse.jl
+++ b/src/Parse.jl
@@ -10,6 +10,8 @@ module Calc
     include("Calculators/Diffusion.jl")
     include("Calculators/Rate.jl")
     include("Calculators/Viscosity.jl")
+    include("Calculators/Thermovec.jl")
+    include("Calculators/Ratevec.jl")
 end
 module Spc
     include("Calculators/ThermoUncertainty.jl")

--- a/src/Phase.jl
+++ b/src/Phase.jl
@@ -1,6 +1,8 @@
 using Parameters
 import Base: length
 
+using SparseArrays
+
 abstract type AbstractPhase end
 export AbstractPhase
 
@@ -40,6 +42,24 @@ export IdealDiluteSolution
     spcdict::Dict{String,Int64}
 end
 export HomogeneousCatalyst
+
+"""
+construct the stochiometric matrix for the reactions and the reaction molecule # change
+"""
+function getstoichmatrix(spcs,rxns)
+    M = zeros(length(rxns),length(spcs))
+    Nrp = zeros(length(rxns))
+    for (i,rxn) in enumerate(rxns)
+        Nrp[i] = Float64(length(rxn.productinds) - length(rxn.reactantinds))
+        for ind in rxn.reactantinds
+            M[i,ind] += 1.0
+        end
+        for ind in rxn.productinds
+            M[i,ind] -= 1.0
+        end
+    end
+    return sparse(M),Nrp
+end
 
 """
 Split the reactions into groups with the same kinetics

--- a/src/Phase.jl
+++ b/src/Phase.jl
@@ -41,6 +41,74 @@ export IdealDiluteSolution
 end
 export HomogeneousCatalyst
 
+"""
+Split the reactions into groups with the same kinetics
+"""
+function splitreactionsbykinetics(rxns)
+    tps = []
+    rxnlists = []
+    for (i,rxn) in enumerate(rxns)
+        typ = getkineticstype(rxn.kinetics)
+        tind = findfirst(x->x==typ,tps)
+        if tind == nothing
+            push!(rxnlists,[])
+            push!(tps,typ)
+            push!(rxnlists[end],rxn)
+        else
+            push!(rxnlists[tind],rxn)
+        end
+    end
+    return (tps,rxnlists)
+end
+export splitreactionsbykinetics
+
+"""
+create vectorized kinetics calculators for the reactions
+"""
+function getveckinetics(rxns)
+    tps,rxnlists = splitreactionsbykinetics(rxns)
+    posinds = Array{Int64,1}()
+    fs = []
+    otherrxns = Array{ElementaryReaction,1}()
+    vecinds = Array{Int64,1}()
+    otherrxninds = Array{Int64,1}()
+    for (i,tp) in enumerate(tps)
+        if typeof(tp)<:Tuple
+            typ = tp[1]
+        else
+            typ = tp
+        end
+        rinds = [findfirst(isequal(rxn),rxns) for rxn in rxnlists[i]]
+        fcn = Symbol(typ * "vec")
+        if !(fcn in allowedfcnlist) || occursin("Troe",typ) #no vectorized kinetics or for the moment stuff with efficiencies
+            append!(otherrxns,rxnlists[i])
+            append!(otherrxninds,rinds)
+        else
+            append!(vecinds,rinds)
+            fcn = eval(fcn)
+            x = fcn([x.kinetics for x in rxnlists[i]])
+            push!(fs,x)
+            if posinds == Array{Int64,1}()
+                push!(posinds,length(rinds))
+            else 
+                push!(posinds,length(rinds)+posinds[end])
+            end
+        end
+    end
+    vectuple = tuple(fs...)
+    return (vectuple,vecinds,otherrxns,otherrxninds,posinds)
+end
+export getveckinetics
+
+"""
+create vectorized thermo calculator for species
+"""
+function getvecthermo(spcs)
+    thermo = [sp.thermo for sp in spcs]
+    typeassert.(thermo,NASA)
+    return NASAvec([sp.thermo for sp in spcs])
+end
+
 length(p::T) where {T<:AbstractPhase} = 1
 export length
 

--- a/src/PhaseState.jl
+++ b/src/PhaseState.jl
@@ -54,7 +54,7 @@ end
 export getkf
 
 @inline function getkfs(ph::U,T::W1,P::W2,C::W3,ns::Q,V::W4) where {U<:AbstractPhase,W1,W2,W3,W4<:Real,Q<:AbstractArray}
-    kfs = zeros(length(ph.reactions))
+    kfs = zeros(Q.parameters[1],length(ph.reactions))
     i = 1
     oldind = 1
     ind = 0

--- a/src/PhaseState.jl
+++ b/src/PhaseState.jl
@@ -168,18 +168,27 @@ Maintains diffusion limitations if the phase has diffusionlimited=true
 end
 export getkfkrev
 
-@inline function getkfkrevs(;phase::U,T::W1,P::W2,C::W3,N::W4,ns::Q1,Gs::Q2,diffs::Q3,V::W5) where {U<:AbstractPhase,W5<:Real,W1<:Real,W2<:Real,W3<:Real,W4<:Real, Q1<:AbstractArray,Q2<:AbstractArray,Q3<:AbstractArray}
-    if !phase.diffusionlimited
-        kf = getkfs(phase,T,P,C,ns,V)
-        krev = @fastmath kf./getKcs(phase,T,Gs)
-    else
+@inline function getkfkrevs(;phase::U,T::W1,P::W2,C::W3,N::W4,ns::Q1,Gs::Q2,diffs::Q3,V::W5,kfs::W6=nothing) where {U<:AbstractPhase,W6,W5<:Real,W1<:Real,W2<:Real,W3<:Real,W4<:Real, Q1<:AbstractArray,Q2<:AbstractArray,Q3<:AbstractArray}
+    if !phase.diffusionlimited && kfs === nothing
+        kfs = getkfs(phase,T,P,C,ns,V)
+        krev = @fastmath kfs./getKcs(phase,T,Gs)
+    elseif !phase.diffusionlimited && !(kfs === nothing)
+        krev = @fastmath kfs./getKcs(phase,T,Gs)
+    elseif phase.diffusionlimited && !(kfs === nothing)
         len = length(phase.reactions)
-        kf = zeros(typeof(N),len)
+        kfs = zeros(typeof(N),len)
         krev = zeros(typeof(N),len)
         @simd for i = 1:len
-           @fastmath @inbounds kf[i],krev[i] = getkfkrev(phase.reactions[i],phase,T,P,C,N,ns,Gs,diffs,V)
+           @fastmath @inbounds kf[i],krev[i] = getkfkrev(phase.reactions[i],phase,T,P,C,N,ns,Gs,diffs,V;kf=kfs[i])
+        end
+    else
+        len = length(phase.reactions)
+        kfs = zeros(typeof(N),len)
+        krev = zeros(typeof(N),len)
+        @simd for i = 1:len
+           @fastmath @inbounds kfs[i],krev[i] = getkfkrev(phase.reactions[i],phase,T,P,C,N,ns,Gs,diffs,V)
         end
     end
-    return kf,krev
+    return kfs,krev
 end
 export getkfkrevs

--- a/src/PhaseState.jl
+++ b/src/PhaseState.jl
@@ -128,8 +128,14 @@ export getKcs
 Calculates the forward and reverse rate coefficients for a given reaction, phase and state
 Maintains diffusion limitations if the phase has diffusionlimited=true
 """
-@inline function getkfkrev(rxn::ElementaryReaction,ph::U,T::W1,P::W2,C::W3,N::W4,ns::Q1,Gs::Q2,diffs::Q3,V::W5) where {U<:AbstractPhase,W5,W4,W1,W2,W3<:Real,Q1,Q2,Q3<:AbstractArray}
-    kf = getkf(rxn,ph,T,P,C,ns,V)
+@inline function getkfkrev(rxn::ElementaryReaction,ph::U,T::W1,P::W2,C::W3,N::W4,ns::Q1,Gs::Q2,diffs::Q3,V::W5;kf::W6=-1.0,f::W7=-1.0) where {U<:AbstractPhase,W6,W7,W5,W4,W1,W2,W3<:Real,Q1,Q2,Q3<:AbstractArray}
+    if signbit(kf) 
+        if signbit(f)
+            kf = getkf(rxn,ph,T,P,C,ns,V)
+        else
+            kf = getkf(rxn,ph,T,P,C,ns,V)*f
+        end
+    end
     Kc = getKc(rxn,ph,T,Gs)
     @fastmath krev = kf/Kc
     if ph.diffusionlimited
@@ -158,7 +164,7 @@ Maintains diffusion limitations if the phase has diffusionlimited=true
             end
         end
     end
-    return (kf,krev)::Tuple{W3,W3}
+    return (kf,krev)
 end
 export getkfkrev
 

--- a/src/ReactionMechanismSimulator.jl
+++ b/src/ReactionMechanismSimulator.jl
@@ -39,6 +39,8 @@ module ReactionMechanismSimulator
     include("Calculators/Diffusion.jl")
     include("Calculators/Rate.jl")
     include("Calculators/Viscosity.jl")
+    include("Calculators/Thermovec.jl")
+    include("Calculators/Ratevec.jl")
     include("Species.jl")
     include("Solvent.jl")
     include("Reaction.jl")

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -42,7 +42,7 @@ export Reactor
 end
 export getrate
 
-@inline function addreactionratecontributions!(dydt::Array{Q,1},rarray::Array{UInt16,2},cs::Array{W,1},kfs::Array{Z,1},krevs::Array{Z,1}) where {Q<:Real,Z<:Real,T<:Integer,W<:Real}
+@inline function addreactionratecontributions!(dydt::Q,rarray::Array{UInt16,2},cs::W,kfs::Z,krevs::Y) where {Q,Z,Y,T,W}
     @inbounds @simd for i = 1:size(rarray)[2]
         if @inbounds rarray[2,i] == 0
             @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -77,8 +77,12 @@ export getrate
 end
 export addreactionratecontributions!
 
-@inline function dydtreactor!(y::Array{U,1},t::Z,domain::Q,interfaces::B;p::RV=nothing,sensitivity::Bool=true) where {RV,B,Z<:Real,U<:Real,J<:Integer,Q<:AbstractDomain}
-    dydt = zeros(U,length(y))
+@inline function dydtreactor!(y::Array{U,1},t::Z,domain::Q,interfaces::B;p::RV=DiffEqBase.NullParameters(),sensitivity::Bool=true) where {RV,B,Z<:Real,U<:Real,J<:Integer,Q<:AbstractDomain}
+    if RV <: AbstractArray && RV.parameters[1] != Float64
+        dydt = zeros(RV.parameters[1],length(y))
+    else
+        dydt = zeros(U,length(y))
+    end
     if sensitivity #if sensitivity isn't explicitly set to false set it to domain.sensitivity
         sensitivity = domain.sensitivity
     end

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -12,7 +12,7 @@ struct Reactor{D<:AbstractDomain} <: AbstractReactor
 end
 
 function Reactor(domain::T,y0::Array{W,1},tspan::Tuple,interfaces::Z=[];p::X=DiffEqBase.NullParameters()) where {T<:AbstractDomain,W<:Real,Z,X}
-    dydt(y::Array{T,1},p::V,t::Q) where {T<:Real,Q<:Real,V} = dydtreactor!(y,t,domain,interfaces;p=p)
+    dydt(y::Array{T,1},p::V,t::Q) where {T<:Real,Q<:Real,V} = dydtreactor!(y,t,domain,interfaces,p=p)
     ode = ODEProblem(dydt,y0,tspan,p)
     return Reactor(domain,ode)
 end


### PR DESCRIPTION
This PR provides a parameter input to dydtreactor! that can be used to modify A factors of reactions and Hf298 for species. It also changes typing to enable use of auto-differentiation on both y and p. This is a big step toward improving sensitivity analysis and enabling it for all domain types. 

Note this PR is built off #31.  