### PR TITLE
Integrate Volume in Constant TP simulations

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -41,7 +41,7 @@ function ConstantTPDomain(;phase::E2,initialconds::Dict{X,X2},constantspecies::A
     #set conditions and initialconditions
     T = 0.0
     P = 0.0
-    y0 = zeros(length(phase.species))
+    y0 = zeros(length(phase.species)+1)
     spnames = [x.name for x in phase.species]
     for (key,val) in initialconds
         if key == "T"
@@ -58,7 +58,7 @@ function ConstantTPDomain(;phase::E2,initialconds::Dict{X,X2},constantspecies::A
 
     @assert T != 0.0
     @assert P != 0.0
-    ns = y0
+    ns = y0[1:end-1]
     N = sum(ns)
 
     if length(constantspecies) > 0
@@ -81,6 +81,7 @@ function ConstantTPDomain(;phase::E2,initialconds::Dict{X,X2},constantspecies::A
     end
     C = P/(R*T)
     V = N*R*T/P
+    y0[end] = V
     kfs,krevs = getkfkrevs(phase=phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
     kfsp = deepcopy(kfs)
     for ind in efficiencyinds
@@ -93,7 +94,7 @@ function ConstantTPDomain(;phase::E2,initialconds::Dict{X,X2},constantspecies::A
         jacobian=zeros(typeof(T),length(phase.species),length(phase.species))
     end
     rxnarray = getreactionindices(phase)
-    return ConstantTPDomain(phase,SVector(phase.species[1].index,phase.species[end].index),constspcinds,
+    return ConstantTPDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1),constspcinds,
         T,P,kfs,krevs,efficiencyinds,Gs,rxnarray,mu,diffs,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
 end
 export ConstantTPDomain

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -57,10 +57,11 @@ getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantTPDomain,ConstantT
 getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ParametrizedVDomain,ConstantPDomain,ParametrizedPDomain},K<:Real,Q,G,L} = bsol.sol(t)[bsol.domain.indexes[3]]
 getT(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ParametrizedTConstantVDomain,ParametrizedTPDomain},K<:Real,Q,G,L} = bsol.domain.T(t)
 export getT
-getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantTPDomain,ConstantPDomain},K<:Real,Q,G,L} = bsol.N(t)*getT(bsol,t)*R /bsol.domain.P
+getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantPDomain},K<:Real,Q,G,L} = bsol.N(t)*getT(bsol,t)*R /bsol.domain.P
 getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantVDomain,ConstantTVDomain,ParametrizedTConstantVDomain},K<:Real,Q,G,L} = bsol.domain.V
 getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ParametrizedVDomain,K<:Real,Q,G,L} = bsol.domain.V(t)
 getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ParametrizedTPDomain,ParametrizedPDomain},K<:Real,Q,G,L} = bsol.N(t)*getT(bsol,t)*R /bsol.domain.P(t)
+getV(bsol::Simulation{Q,W,L,G}, t::K) where {W<:ConstantTPDomain,K<:Real,Q,G,L} = bsol.sol(t)[bsol.domain.indexes[3]]
 export getV
 getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantTPDomain,ConstantPDomain},K<:Real,Q,G,L} = bsol.domain.P
 getP(bsol::Simulation{Q,W,L,G}, t::K) where {W<:Union{ConstantTVDomain,ParametrizedTConstantVDomain},K<:Real,Q,G,L} = 1.0e6

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -43,7 +43,7 @@ h2ind = findfirst(isequal("H2"),spcnames)
 o2ind = findfirst(isequal("O2"),spcnames)
 h2oind = findfirst(isequal("H2O"),spcnames)
 y = sol(20.44002454)
-N = sum(y)
+N = sim.N(20.44002454)
 @test y[h2ind]/N ≈ 0.412883111 rtol=1e-4 #from RMG simulator
 @test y[o2ind]/N ≈ 0.200419093 rtol=1e-4
 @test y[h2oind]/N ≈ 0.386618602 rtol=1e-4
@@ -59,7 +59,9 @@ ind = findfirst(isequal("H2"),sim2.names)
 dpvs = [v[ind] for v in dp]
 dpvs[length(domain.phase.species)+1:end] .*= domain.p[length(domain.phase.species)+1:end]
 dpvs ./= sol2(150.11094)[ind]
-@test all((abs.((dpvs .- dps')./dpvs) .> 1e-2).==false)
+rerr = (dpvs .- dps')./dpvs
+rerr = [isinf(x) ? 0.0 : x for x in rerr]
+@test all((abs.(rerr) .> 1e-2).==false)
 end;
 
 #Constant V adiabatic Ideal Gas


### PR DESCRIPTION
RMS currently uses the formulation of Ideal Gas Constant T and P equations used in RMG where you simply integrate the moles of each species. However, this formulation of the problem is problematic. When converting each reaction rate from (mol/(m3*s)) to (mol/s) you multiply by the volume, however in this type of reactor V = N*R*T/P = R*T/P * sum_i(N_i) this makes dN_i/dt coupled to the all of the other N_i making the Jacobian dense. This PR integrates the volume explicitly making all the dN_i/dt dependent on volume and the species involved in reactions that produce or consume it making the Jacobian sparse.  