### PR TITLE
Analytic jacobian

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1585,6 +1585,24 @@ end
 end
 export calcdomainderivatives!
 
+@inline function jacobianyefficiencyderiv!(jac::S,domain::Union{ConstantTPDomain,ConstantPDomain,ParametrizedTPDomain,ParametrizedPDomain},kinetics::AbstractFalloffRate,efficiencies::Dict{Int64,Float64},rxnarray::Array{Int64,2},rxnind::Int64,Vind::Int64,cs::Array{Float64,1},T::Float64,V::Float64,C::Float64,Ceff::Float64,Kc::Float64) where {S<:AbstractArray}
+    dkdCeff = _calcdkdCeff(kinetics,T,Ceff)
+    for (spcind,efficiencyval) in efficiencies
+        @fastmath dkdni = dkdCeff*(efficiencyval/V)
+        _jacobianykderiv!(jac,spcind,dkdni,dkdni/Kc,rxnarray,rxnind,cs,V)
+    end
+    @fastmath dkdV = dkdCeff*(C-Ceff)/V
+    _jacobianykderiv!(jac,Vind,dkdV,dkdV/Kc,rxnarray,rxnind,cs,V)
+end
+
+@inline function jacobianyefficiencyderiv!(jac::S,domain::Union{ConstantVDomain,ParametrizedVDomain,ConstantTVDomain,ParametrizedTConstantVDomain},kinetics::AbstractFalloffRate,efficiencies::Dict{Int64,Float64},rxnarray::AbstractArray,rxnind::Int64,Vind::Int64,cs::Array{Float64,1},T::Float64,V::Float64,C::Float64,Ceff::Float64,Kc::Float64) where {S<:AbstractArray}
+    dkdCeff = _calcdkdCeff(kinetics,T,Ceff)
+    for (spcind,efficiencyval) in efficiencies
+        @fastmath dkdni = dkdCeff*(efficiencyval/V)
+        _jacobianykderiv!(jac,spcind,dkdni,dkdni/Kc,rxnarray,rxnind,cs,V)
+    end
+end
+
 function getreactionindices(ig::Q) where {Q<:AbstractPhase}
     arr = zeros(Int64,(6,length(ig.reactions)))
     for (i,rxn) in enumerate(ig.reactions)

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -672,8 +672,8 @@ export ConstantTADomain
         d.jacuptodate[1] = false
     end
     ns = y[d.indexes[1]:d.indexes[2]]
-    N = sum(ns)
-    V = y[d.indexes[3]] 
+    V = y[d.indexes[3]]
+    N = d.P*V/(R*d.T)
     cs = ns./V
     C = N/V
     for ind in d.efficiencyinds #efficiency related rates may have changed
@@ -688,8 +688,8 @@ end
         d.jacuptodate[1] = false
     end
     ns = y[d.indexes[1]:d.indexes[2]]
-    N = sum(ns)
     V = y[d.indexes[3]]
+    N = d.P*V/(R*d.T)
     cs = ns./V
     C = N/V
     @views kfps = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
@@ -723,8 +723,8 @@ end
         d.jacuptodate[1] = false
     end
     ns = y[d.indexes[1]:d.indexes[2]]
-    N = sum(ns)
     V = y[d.indexes[3]]
+    N = d.P*V/(R*d.T)
     cs = ns./V
     C = N/V
     kfs = convert(typeof(y),p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)])
@@ -742,8 +742,8 @@ end
         d.jacuptodate[1] = false
     end
     ns = y[d.indexes[1]:d.indexes[2]]
-    N = sum(ns)
     V = y[d.indexes[3]]
+    N = d.P*V/(R*d.T)
     cs = ns./V
     C = N/V
     kfs = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
@@ -761,8 +761,8 @@ end
         d.jacuptodate[1] = false
     end
     ns = y[d.indexes[1]:d.indexes[2]]
-    N = sum(ns)
     V = y[d.indexes[3]]
+    N = d.P*V/(R*d.T)
     cs = ns./V
     C = N/V
     Gs = p[1:length(d.phase.species)]
@@ -778,10 +778,10 @@ end
     end
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
+    P = y[d.indexes[4]]
+    N = P*d.V/(R*T)
     cs = ns./d.V
     C = N/d.V
-    P = y[d.indexes[4]]
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
     Cvave = 0.0
@@ -807,10 +807,10 @@ end
     end
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
+    P = y[d.indexes[4]]
+    N = P*d.V/(R*T)
     cs = ns./d.V
     C = N/d.V
-    P = y[d.indexes[4]]
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
     Cvave = 0.0
@@ -837,10 +837,10 @@ end
     end
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
+    P = y[d.indexes[4]]
+    N = P*d.V/(R*T)
     cs = ns./d.V
     C = N/d.V
-    P = y[d.indexes[4]]
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
     Cvave = 0.0
@@ -867,8 +867,8 @@ end
     end
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
     V = y[d.indexes[4]]
+    N = d.P*V/(R*T)
     cs = ns./V
     C = N/V
     Gs = zeros(length(d.phase.species))
@@ -895,8 +895,8 @@ end
     end
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
     V = y[d.indexes[4]]
+    N = d.P*V/(R*T)
     cs = ns./V
     C = N/V
     Gs = zeros(length(d.phase.species))
@@ -928,8 +928,8 @@ end
     end
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
     V = y[d.indexes[4]]
+    N = d.P*V/(R*T)
     cs = ns./V
     C = N/V
     Gs = zeros(length(d.phase.species))
@@ -958,10 +958,10 @@ end
     V = d.V(t)
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
+    P = y[d.indexes[4]]
+    N = P*V/(R*T)
     cs = ns./V
     C = N/V
-    P = y[d.indexes[4]]
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
     cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
@@ -987,10 +987,10 @@ end
     V = d.V(t)
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
+    P = y[d.indexes[4]]
+    N = P*V/(R*T)
     cs = ns./V
     C = N/V
-    P = y[d.indexes[4]]
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
     cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
@@ -1017,10 +1017,10 @@ end
     V = d.V(t)
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
+    P = y[d.indexes[4]]
+    N = P*V/(R*T)
     cs = ns./V
     C = N/V
-    P = y[d.indexes[4]]
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
     cpdivR,hdivRT1,sdivR = calcHSCpdless(d.phase.vecthermo,T)
@@ -1047,8 +1047,8 @@ end
     P = d.P(t)
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
     V = y[d.indexes[4]]
+    N = P*V/(R*T)
     cs = ns./V
     C = N/V
     Gs = zeros(length(d.phase.species))
@@ -1076,8 +1076,8 @@ end
     P = d.P(t)
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
     V = y[d.indexes[4]]
+    N = P*V/(R*T)
     cs = ns./V
     C = N/V
     Gs = zeros(length(d.phase.species))
@@ -1105,8 +1105,8 @@ end
     P = d.P(t)
     ns = y[d.indexes[1]:d.indexes[2]]
     T = y[d.indexes[3]]
-    N = sum(ns)
     V = y[d.indexes[4]]
+    N = P*V/(R*T)
     cs = ns./V
     C = N/V
     Gs = zeros(length(d.phase.species))
@@ -1213,8 +1213,8 @@ end
     @assert T < 10000.0
     P = d.P(t)
     ns = y[d.indexes[1]:d.indexes[2]]
-    N = sum(ns)
     V = y[d.indexes[3]]
+    N = P*V/(R*T)
     cs = ns./V
     C = N/V
     Gs = zeros(length(d.phase.species))
@@ -1242,8 +1242,8 @@ end
     @assert T < 10000.0
     P = d.P(t)
     ns = y[d.indexes[1]:d.indexes[2]]
-    N = sum(ns)
     V = y[d.indexes[3]]
+    N = P*V/(R*T)
     cs = ns./V
     C = N/V
     Gs = zeros(length(d.phase.species))
@@ -1272,8 +1272,8 @@ end
     @assert T < 10000.0
     P = d.P(t)
     ns = y[d.indexes[1]:d.indexes[2]]
-    N = sum(ns)
     V = y[d.indexes[3]]
+    N = P*V/(R*T)
     cs = ns./V
     C = N/V
     Gs = zeros(length(d.phase.species))

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1365,7 +1365,6 @@ end
     kfs,krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=d.V,kfs=kfsnondiff)
     return ns,cs,d.T,P,d.V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
 end
-export calcthermo
 
 @inline function calcthermo(d::ConstantTADomain{W,Y},y::J,t::Q,p::Q2=DiffEqBase.NullParameters()) where {Q2<:DiffEqBase.NullParameters,W<:IdealSurface,Y<:Integer,J<:AbstractArray,Q<:Real}
     if t != d.t[1]

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -475,7 +475,7 @@ function ConstantTVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arr
     #set conditions and initialconditions
     T = 0.0
     V = 0.0
-    P = 1.0e9
+    P = 1.0e8
     y0 = zeros(length(phase.species))
     spnames = [x.name for x in phase.species]
     for (key,val) in initialconds
@@ -514,7 +514,7 @@ function ConstantTVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arr
     else
         diffs = Array{Float64,1}()
     end
-    P = 1.0e9  #essentiallly assuming this is a liquid
+    P = 1.0e8  #essentiallly assuming this is a liquid
     C = N/V
     kfs,krevs = getkfkrevs(phase=phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
     kfsnondiff = getkfs(phase,T,P,C,ns,V)
@@ -1138,7 +1138,7 @@ end
     N = sum(ns)
     cs = ns./V
     C = N/V
-    P = C*R*T
+    P = 1.0e8 #liquid phase
     Gs = zeros(length(d.phase.species))
     mu = d.phase.solvent.mu(T)
     cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
@@ -1163,7 +1163,7 @@ end
     N = sum(ns)
     cs = ns./V
     C = N/V
-    P = C*R*T
+    P = 1.0e8 #liquid phase
     Gs = zeros(length(d.phase.species))
     mu = d.phase.solvent.mu(T)
     cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
@@ -1189,7 +1189,7 @@ end
     N = sum(ns)
     cs = ns./V
     C = N/V
-    P = C*R*T
+    P = 1.0e8 #liquid phase
     Gs = zeros(length(d.phase.species))
     mu = d.phase.solvent.mu(T)
     cpdivR,hdivRT1,sdivR = calcHSCpdless(d.phase.vecthermo,T)
@@ -1302,7 +1302,7 @@ end
     N = sum(ns)
     cs = ns./d.V
     C = N/d.V
-    P = 1.0e9
+    P = 1.0e8
     return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
 end
 
@@ -1315,7 +1315,7 @@ end
     N = sum(ns)
     cs = ns./d.V
     C = N/d.V
-    P = 1.0e9
+    P = 1.0e8
     @views nothermochg = d.Gs == p[1:length(d.phase.species)]
     @views nokfchg = d.kfsnondiff == p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
     if nothermochg && nokfchg
@@ -1341,7 +1341,7 @@ end
     N = sum(ns)
     cs = ns./d.V
     C = N/d.V
-    P = 1.0e9
+    P = 1.0e8
     Gs = p[1:length(d.phase.species)]
     kfsnondiff = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
     kfs,krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=d.V,kfs=kfsnondiff)
@@ -1359,7 +1359,7 @@ end
     N = sum(ns)
     cs = ns./d.V
     C = N/d.V
-    P = 1.0e9
+    P = 1.0e8
     Gs = p[1:length(d.phase.species)]
     kfsnondiff = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
     kfs,krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=d.V,kfs=kfsnondiff)

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -299,7 +299,7 @@ function ParametrizedTPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecie
         jacobian=zeros(typeof(V),length(phase.species)+1,length(phase.species)+1)
     end
     rxnarray = getreactionindices(phase)
-    return ParametrizedTPDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end]+1),constspcinds,
+    return ParametrizedTPDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1),constspcinds,
     Tfcn,Pfcn,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
 end
 export ParametrizedTPDomain

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -673,7 +673,7 @@ export ConstantTADomain
     end
     ns = y[d.indexes[1]:d.indexes[2]]
     N = sum(ns)
-    V = N*d.T*R/d.P
+    V = y[d.indexes[3]] 
     cs = ns./V
     C = N/V
     for ind in d.efficiencyinds #efficiency related rates may have changed

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1320,12 +1320,17 @@ end
     C = N/d.V
     P = 1.0e9
     @views nothermochg = d.Gs == p[1:length(d.phase.species)]
-    if nothermochg
-        return ns,cs,d.T,P,d.V,C,N,d.mu,p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)],d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    @views nokfchg = d.kfsnondiff == p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
+    if nothermochg && nokfchg
+        return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    elseif nothermochg
+        d.kfsnondiff = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
+        d.kfs,d.krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=d.Gs,diffs=d.diffusivity,V=d.V,kfs=d.kfsnondiff)
+        return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
     else
-        d.kfs = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
+        d.kfsnondiff = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
         d.Gs = p[1:length(d.phase.species)]
-        d.krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=d.Gs,diffs=d.diffusivity,V=d.V,kfs=d.kfs)[2]
+        d.kfs,d.krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=d.Gs,diffs=d.diffusivity,V=d.V,kfs=d.kfsnondiff)
         return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
     end
 end
@@ -1341,8 +1346,10 @@ end
     C = N/d.V
     P = 1.0e9
     Gs = p[1:length(d.phase.species)]
-    kfs = convert(typeof(y),p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)])
-    krevs = convert(typeof(y),getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=d.V,kfs=kfs)[2])
+    kfsnondiff = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
+    kfs,krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=d.V,kfs=kfsnondiff)
+    kfs = convert(typeof(y),kfs)
+    krevs = convert(typeof(y),krevs)
     return ns,cs,d.T,P,d.V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
 end
 
@@ -1357,8 +1364,8 @@ end
     C = N/d.V
     P = 1.0e9
     Gs = p[1:length(d.phase.species)]
-    kfs = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
-    krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=d.V,kfs=kfs)[2]
+    kfsnondiff = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
+    kfs,krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=d.V,kfs=kfsnondiff)
     return ns,cs,d.T,P,d.V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
 end
 export calcthermo

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1904,6 +1904,8 @@ function jacobiany!(jac::Q,y::U,p::W,t::Z,domain::D,interfaces::Q3,colorvec::Q2=
     return jac
 end
 
+export jacobiany!
+
 function getreactionindices(ig::Q) where {Q<:AbstractPhase}
     arr = zeros(Int64,(6,length(ig.reactions)))
     for (i,rxn) in enumerate(ig.reactions)

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -458,6 +458,7 @@ export ParametrizedPDomain
     V::W
     kfs::Array{W,1}
     krevs::Array{W,1}
+    kfsnondiff::Array{W,1}
     efficiencyinds::Array{I,1}
     Gs::Array{W,1}
     rxnarray::Array{Int64,2}
@@ -516,7 +517,8 @@ function ConstantTVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arr
     P = 1.0e9  #essentiallly assuming this is a liquid
     C = N/V
     kfs,krevs = getkfkrevs(phase=phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    p = vcat(Gs,kfs)
+    kfsnondiff = getkfs(phase,T,P,C,ns,V)
+    p = vcat(Gs,kfsnondiff)
     if sparse
         jacobian=zeros(typeof(T),length(phase.species),length(phase.species))
     else
@@ -524,7 +526,7 @@ function ConstantTVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arr
     end
     rxnarray = getreactionindices(phase)
     return ConstantTVDomain(phase,SVector(phase.species[1].index,phase.species[end].index),constspcinds,
-        T,V,kfs,krevs,efficiencyinds,Gs,rxnarray,mu,diffs,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+        T,V,kfs,krevs,kfsnondiff,efficiencyinds,Gs,rxnarray,mu,diffs,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
 end
 export ConstantTVDomain
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1785,6 +1785,54 @@ function jacobiany!(jac::Q,y::U,p::W,t::Z,domain::D,interfaces::Q3,colorvec::Q2=
     return jac
 end
 
+function jacobiany!(jac::Q,y::U,p::W,t::Z,domain::D,interfaces::Q3,colorvec::Q2=nothing) where {Q3<:AbstractArray,Q2,Q<:AbstractArray,U<:AbstractArray,W,Z<:Real,D<:ParametrizedVDomain}
+    ns,cs,T,P,V,C,N,mu,kfs,krevs,Hs,Us,Gs,diffs,Cvave,cpdivR = calcthermo(domain,y,t,p)
+    jacobianynsderiv!(jac,domain,domain.rxnarray,domain.efficiencyinds,cs,kfs,krevs,T,V,C)
+    
+    dydt = zeros(size(y))
+    addreactionratecontributions!(dydt,domain.rxnarray,cs,kfs,krevs)
+    dydt .*= V
+    
+    dVdt = Calculus.derivative(domain.V,t)
+    @simd for i in domain.indexes[1]:domain.indexes[2]
+        @fastmath @inbounds dCvavedni = cpdivR[i]*R/N
+        @views @inbounds @fastmath jac[domain.indexes[3],i] = -dot(Us,jac[domain.indexes[1]:domain.indexes[2],i])/(N*Cvave)-(-dot(Us,dydt[domain.indexes[1]:domain.indexes[2]])-P*dVdt)/(N*Cvave*Cvave)*dCvavedni
+        @views @inbounds @fastmath jac[domain.indexes[4],i] = sum(jac[domain.indexes[1]:domain.indexes[2],i])*R*T/V + P/T*jac[domain.indexes[3],i]
+    end
+    
+    @simd for ind in domain.constantspeciesinds
+        @inbounds jac[ind,:] .= 0.
+    end
+    
+    @simd for inter in interfaces
+        if isa(inter,Inlet) && domain == inter.domain
+            flow = inter.F(t)
+            @fastmath dTdt = flow*(inter.H - dot(Us,ns)/N)/(N*Cvave)
+            @simd for i in domain.indexes[1]:domain.indexes[2]
+                @inbounds @fastmath dCvavedni = cpdivR[i]*R/N
+                @inbounds @fastmath ddnidTdt = flow*(-Us[i]/N)/(N*Cvave)-dTdt*(dCvavedni/Cvave)
+                @inbounds jac[domain.indexes[3],i] += ddnidTdt
+                @inbounds @fastmath jac[domain.indexes[4],i] += P/T*ddnidTdt
+            end
+        elseif isa(inter,Outlet) && domain == inter.domain
+            flow = inter.F(t)
+            @fastmath dTdt = (P*V/N*flow)/(N*Cvave)
+            @simd for i in domain.indexes[1]:domain.indexes[2]
+                @inbounds @fastmath jac[i,i] .-= flow/N
+                @inbounds @fastmath dCvavedni = cpdivR[i]*R/N
+                @fastmath ddnidTdt = -dTdt*(dCvavedni/Cvave)
+                @inbounds jac[domain.indexes[3],i] -= ddnidTdt
+                @inbounds @fastmath jac[domain.indexes[4],i] -= P/T*ddnidTdt
+            end
+        end
+    end
+    
+    @inbounds jacobianytherm!(jac,y,p,t,domain,interfaces,domain.indexes[3],T,colorvec)
+    @inbounds jacobianytherm!(jac,y,p,t,domain,interfaces,domain.indexes[4],P,colorvec)
+
+    return jac
+end
+
 function getreactionindices(ig::Q) where {Q<:AbstractPhase}
     arr = zeros(Int64,(6,length(ig.reactions)))
     for (i,rxn) in enumerate(ig.reactions)

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1758,6 +1758,33 @@ function jacobiany!(jac::Q,y::U,p::W,t::Z,domain::D,interfaces::Q3,colorvec::Q2=
     return jac
 end
 
+function jacobiany!(jac::Q,y::U,p::W,t::Z,domain::D,interfaces::Q3,colorvec::Q2=nothing) where {Q3<:AbstractArray,Q2,Q<:AbstractArray,U<:AbstractArray,W,Z<:Real,D<:ParametrizedTPDomain}
+    ns,cs,T,P,V,C,N,mu,kfs,krevs,Hs,Us,Gs,diffs,Cvave,cpdivR = calcthermo(domain,y,t,p)
+    jacobianynsderiv!(jac,domain,domain.rxnarray,domain.efficiencyinds,cs,kfs,krevs,T,V,C)
+    
+    @simd for i in domain.indexes[1]:domain.indexes[2]
+        @views @inbounds @fastmath jac[domain.indexes[3],i] = sum(jac[domain.indexes[1]:domain.indexes[2],i])*R*T/P
+    end
+    @views @inbounds @fastmath jac[domain.indexes[3],domain.indexes[3]] = sum(jac[domain.indexes[1]:domain.indexes[2],domain.indexes[3]])*R*T/P
+    
+    @simd for ind in domain.constantspeciesinds
+        @inbounds jac[ind,:] .= 0.
+    end
+    
+    @simd for inter in interfaces
+        if isa(inter,Outlet) && domain == inter.domain
+            flow = inter.F(t)
+            @simd for i in domain:indexes[1]:domain.indexes[2]
+                @inbounds @fastmath jac[i,i] .-= flow/N
+            end
+        end
+    end
+    
+    @inbounds jacobianytherm!(jac,y,p,t,domain,interfaces,domain.indexes[3],V,colorvec)
+    
+    return jac
+end
+
 function getreactionindices(ig::Q) where {Q<:AbstractPhase}
     arr = zeros(Int64,(6,length(ig.reactions)))
     for (i,rxn) in enumerate(ig.reactions)

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1924,3 +1924,23 @@ function getspline(xs,vals;s=1e-10)
     F(x::T) where {T} = predict(smspl,x)
     return F
 end
+
+function getthermovariableindex(domain::Union{ConstantTPDomain,ParametrizedTPDomain},target::String)
+    return domain.indexes[3]
+end
+
+function getthermovariableindex(domain::Union{ConstantVDomain,ParametrizedVDomain},target::String)
+    if target == "T"
+        return domain.indexes[3]
+    elseif target == "P"
+        return domain.indexes[4]
+    end
+end
+
+function getthermovariableindex(domain::Union{ConstantPDomain,ParametrizedPDomain},target::String)
+    if target == "T"
+        return domain.indexes[3]
+    elseif target == "V"
+        return domain.indexes[4]
+    end
+end

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -679,7 +679,7 @@ export ConstantTADomain
     for ind in d.efficiencyinds #efficiency related rates may have changed
         d.kfs[ind],d.krevs[ind] = getkfkrev(d.phase.reactions[ind],d.phase,d.T,d.P,C,N,ns,d.Gs,d.diffusivity,V)
     end
-    return ns,cs,d.T,d.P,V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    return ns,cs,d.T,d.P,V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ConstantTPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealGas,Y<:Integer,J<:Array{Float64,1},Q<:Float64} #uses parameter input
@@ -699,13 +699,13 @@ end
         for ind in d.efficiencyinds #efficiency related rates may have changed
             d.kfs[ind],d.krevs[ind] = getkfkrev(d.phase.reactions[ind],d.phase,d.T,d.P,C,N,ns,d.Gs,d.diffusivity,V;f=kfps[ind])
         end
-        return ns,cs,d.T,d.P,V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+        return ns,cs,d.T,d.P,V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
     elseif nothermochg
         d.kfs = kfps
         for ind in d.efficiencyinds #efficiency related rates may have changed
             d.kfs[ind],d.krevs[ind] = getkfkrev(d.phase.reactions[ind],d.phase,d.T,d.P,C,N,ns,d.Gs,d.diffusivity,V;f=kfps[ind]) 
         end
-        return ns,cs,d.T,d.P,V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+        return ns,cs,d.T,d.P,V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
     else #need to handle thermo changes
         d.kfs = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
         d.Gs = p[1:length(d.phase.species)]
@@ -713,7 +713,7 @@ end
         for ind in d.efficiencyinds #efficiency related rates may have changed
             d.kfs[ind],d.krevs[ind] = getkfkrev(d.phase.reactions[ind],d.phase,d.T,d.P,C,N,ns,d.Gs,d.diffusivity,V;f=kfps[ind])
         end
-        return ns,cs,d.T,d.P,V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+        return ns,cs,d.T,d.P,V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
     end
 end
 
@@ -733,7 +733,7 @@ end
     for ind in d.efficiencyinds #efficiency related rates may have changed
         kfs[ind],krevs[ind] = getkfkrev(d.phase.reactions[ind],d.phase,d.T,d.P,C,N,ns,Gs,d.diffusivity,V;f=kfs[ind])
     end
-    return ns,cs,d.T,d.P,V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    return ns,cs,d.T,d.P,V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ConstantTPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2,W<:IdealGas,Y<:Integer,J,Q} #Autodiff p
@@ -752,7 +752,7 @@ end
     for ind in d.efficiencyinds #efficiency related rates may have changed
         kfs[ind],krevs[ind] = getkfkrev(d.phase.reactions[ind],d.phase,d.T,d.P,C,N,ns,Gs,d.diffusivity,V;f=kfs[ind])
     end
-    return ns,cs,d.T,d.P,V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    return ns,cs,d.T,d.P,V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ConstantTPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Union{ReverseDiff.TrackedArray,Tracker.TrackedArray},W<:IdealGas,Y<:Integer,J,Q} #Tracker/reversediff
@@ -768,7 +768,7 @@ end
     Gs = p[1:length(d.phase.species)]
     kfs = [ind in d.efficiencyinds ? getkfkrev(d.phase.reactions[ind],d.phase,d.T,d.P,C,N,ns,Gs,d.diffusivity,V)[1]*p[length(d.phase.species)+ind] : p[length(d.phase.species)+ind] for ind in 1:length(d.phase.reactions)]
     krevs = getkfkrevs(;phase=d.phase,T=d.T,P=d.P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=V,kfs=kfs)[2]
-    return ns,cs,d.T,d.P,V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    return ns,cs,d.T,d.P,V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ConstantVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -797,7 +797,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=d.V)
-    return ns,cs,T,P,d.V,C,N,0.0,kfs,krevs,Array{Float64,1}(),Us,Gs,diffs,Cvave
+    return ns,cs,T,P,d.V,C,N,0.0,kfs,krevs,Array{Float64,1}(),Us,Gs,diffs,Cvave,cpdivR
 end
 
 @inline function calcthermo(d::ConstantVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -827,7 +827,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=d.V)
-    return @views @fastmath ns,cs,T,P,d.V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave
+    return @views @fastmath ns,cs,T,P,d.V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave,cpdivR
 end
 
 @inline function calcthermo(d::ConstantVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -857,7 +857,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=d.V)
-    return @views @fastmath ns,cs,T,P,d.V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave
+    return @views @fastmath ns,cs,T,P,d.V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave,cpdivR
 end
 
 @inline function calcthermo(d::ConstantPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -885,7 +885,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=d.P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return ns,cs,T,d.P,V,C,N,0.0,kfs,krevs,Hs,Array{Float64,1}(),Gs,diffs,Cvave
+    return ns,cs,T,d.P,V,C,N,0.0,kfs,krevs,Hs,Array{Float64,1}(),Gs,diffs,Cvave,cpdivR
 end
 
 @inline function calcthermo(d::ConstantPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -915,9 +915,9 @@ end
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=d.P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
     if p != DiffEqBase.NullParameters()
-        return @views @fastmath ns,cs,T,d.P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave
+        return @views @fastmath ns,cs,T,d.P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave,cpdivR
     else
-        return ns,cs,T,d.P,V,C,N,0.0,kfs,krevs,Hs,Array{Float64,1}(),Gs,diffs,Cvave
+        return ns,cs,T,d.P,V,C,N,0.0,kfs,krevs,Hs,Array{Float64,1}(),Gs,diffs,Cvave,cpdivR
     end
 end
 
@@ -947,7 +947,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=d.P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return @views @fastmath ns,cs,T,d.P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave
+    return @views @fastmath ns,cs,T,d.P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave,cpdivR
 end
 
 @inline function calcthermo(d::ParametrizedVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -976,7 +976,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,Array{Float64,1}(),Us,Gs,diffs,Cvave
+    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,Array{Float64,1}(),Us,Gs,diffs,Cvave,cpdivR
 end
 
 @inline function calcthermo(d::ParametrizedVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -1006,7 +1006,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave,cpdivR
 end
 
 @inline function calcthermo(d::ParametrizedVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -1036,7 +1036,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Us,Gs,diffs,Cvave,cpdivR
 end
 
 @inline function calcthermo(d::ParametrizedPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -1065,7 +1065,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,Hs,Array{Float64,1}(),Gs,diffs,Cvave
+    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,Hs,Array{Float64,1}(),Gs,diffs,Cvave,cpdivR
 end
 
 @inline function calcthermo(d::ParametrizedPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -1095,7 +1095,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave,cpdivR
 end
 @inline function calcthermo(d::ParametrizedPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
     if t != d.t[1]
@@ -1124,7 +1124,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Hs,Array{Float64,1}(),Gs,diffs,Cvave,cpdivR
 end
 
 @inline function calcthermo(d::ParametrizedTConstantVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealDiluteSolution,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -1149,7 +1149,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return ns,cs,T,P,V,C,N,mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
+    return ns,cs,T,P,V,C,N,mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ParametrizedTConstantVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealDiluteSolution,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -1175,7 +1175,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return @views @fastmath ns,cs,T,P,V,C,N,mu,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
+    return @views @fastmath ns,cs,T,P,V,C,N,mu,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ParametrizedTConstantVDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2,W<:IdealDiluteSolution,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -1201,7 +1201,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return @views @fastmath ns,cs,T,P,V,C,N,mu,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
+    return @views @fastmath ns,cs,T,P,V,C,N,mu,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ParametrizedTPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:DiffEqBase.NullParameters,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -1230,7 +1230,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
+    return ns,cs,T,P,V,C,N,0.0,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ParametrizedTPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2<:Array{Float64,1},W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -1260,7 +1260,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ParametrizedTPDomain{W,Y},y::J,t::Q,p::W2=DiffEqBase.NullParameters()) where {W2,W<:IdealGas,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -1290,7 +1290,7 @@ end
         diffs = Array{Float64,1}()
     end
     kfs,krevs = getkfkrevs(phase=d.phase,T=T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=diffs,V=V)
-    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0
+    return @views @fastmath ns,cs,T,P,V,C,N,0.0,kfs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],krevs.*p[length(d.phase.species)+1:length(d.phase.species)+length(kfs)],Array{Float64,1}(),Array{Float64,1}(),Gs,diffs,0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ConstantTVDomain{W,Y},y::J,t::Q,p::Q2=DiffEqBase.NullParameters()) where {Q2<:DiffEqBase.NullParameters,W<:IdealDiluteSolution,Y<:Integer,J<:AbstractArray,Q<:Real}
@@ -1303,7 +1303,7 @@ end
     cs = ns./d.V
     C = N/d.V
     P = 1.0e8
-    return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ConstantTVDomain{W,Y},y::J,t::Q,p::Q2=DiffEqBase.NullParameters()) where {Q2<:Array{Float64,1},W<:IdealDiluteSolution,Y<:Integer,J<:Array{Float64,1},Q<:Real}
@@ -1319,16 +1319,16 @@ end
     @views nothermochg = d.Gs == p[1:length(d.phase.species)]
     @views nokfchg = d.kfsnondiff == p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
     if nothermochg && nokfchg
-        return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+        return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
     elseif nothermochg
         d.kfsnondiff = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
         d.kfs,d.krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=d.Gs,diffs=d.diffusivity,V=d.V,kfs=d.kfsnondiff)
-        return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+        return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
     else
         d.kfsnondiff = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
         d.Gs = p[1:length(d.phase.species)]
         d.kfs,d.krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=d.Gs,diffs=d.diffusivity,V=d.V,kfs=d.kfsnondiff)
-        return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+        return ns,cs,d.T,P,d.V,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
     end
 end
 
@@ -1347,7 +1347,7 @@ end
     kfs,krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=d.V,kfs=kfsnondiff)
     kfs = convert(typeof(y),kfs)
     krevs = convert(typeof(y),krevs)
-    return ns,cs,d.T,P,d.V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    return ns,cs,d.T,P,d.V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ConstantTVDomain{W,Y},y::J,t::Q,p::Q2=DiffEqBase.NullParameters()) where {Q2,W<:IdealDiluteSolution,Y<:Integer,J<:AbstractArray,Q<:Real} #autodiff p
@@ -1363,7 +1363,7 @@ end
     Gs = p[1:length(d.phase.species)]
     kfsnondiff = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
     kfs,krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=d.V,kfs=kfsnondiff)
-    return ns,cs,d.T,P,d.V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    return ns,cs,d.T,P,d.V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
 end
 export calcthermo
 
@@ -1377,7 +1377,7 @@ export calcthermo
     cs = ns./d.A
     C = N/d.A
     P = 0.0
-    return ns,cs,d.T,P,d.A,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    return ns,cs,d.T,P,d.A,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ConstantTADomain{W,Y},y::J,t::Q,p::Q2=DiffEqBase.NullParameters()) where {Q2<:Array{Float64,1},W<:IdealSurface,Y<:Integer,J<:Array{Float64,1},Q<:Real}
@@ -1397,7 +1397,7 @@ end
         d.kfs = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
         d.Gs = p[1:length(d.phase.species)]
         d.krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=d.Gs,diffs=d.diffusivity,V=d.V,kfs=d.kfs)[2]
-        return ns,cs,d.T,P,d.A,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+        return ns,cs,d.T,P,d.A,C,N,d.mu,d.kfs,d.krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
     end
 end
 
@@ -1414,7 +1414,7 @@ end
     Gs = p[1:length(d.phase.species)]
     kfs = convert(typeof(y),p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)])
     krevs = convert(typeof(y),getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=d.V,kfs=kfs)[2])
-    return ns,cs,d.T,P,d.V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    return ns,cs,d.T,P,d.V,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
 end
 
 @inline function calcthermo(d::ConstantTADomain{W,Y},y::J,t::Q,p::Q2=DiffEqBase.NullParameters()) where {Q2,W<:IdealSurface,Y<:Integer,J<:AbstractArray,Q<:Real} #autodiff p
@@ -1430,7 +1430,7 @@ end
     Gs = p[1:length(d.phase.species)]
     kfs = p[length(d.phase.species)+1:length(d.phase.species)+length(d.phase.reactions)]
     krevs = getkfkrevs(;phase=d.phase,T=d.T,P=P,C=C,N=N,ns=ns,Gs=Gs,diffs=d.diffusivity,V=d.V,kfs=kfs)[2]
-    return ns,cs,d.T,P,d.A,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0
+    return ns,cs,d.T,P,d.A,C,N,d.mu,kfs,krevs,Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),Array{Float64,1}(),0.0,Array{Float64,1}()
 end
 export calcthermo
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1638,6 +1638,30 @@ end
     end
 end
 
+@inline function jacobiany!(jac::Q,y::U,p::W,t::Z,domain::D,interfaces::Q3,colorvec::Q2=nothing) where {Q3<:AbstractArray,Q2,Q<:AbstractArray,U<:AbstractArray,W,Z<:Real,D<:ConstantTPDomain}
+    ns,cs,T,P,V,C,N,mu,kfs,krevs,Hs,Us,Gs,diffs,Cvave,cpdivR = calcthermo(domain,y,t,p)
+    jacobianynsderiv!(jac,domain,domain.rxnarray,domain.efficiencyinds,cs,kfs,krevs,T,V,C)
+    
+    @simd for i in domain.indexes[1]:domain.indexes[2]
+        @views @inbounds @fastmath jac[domain.indexes[3],i] = sum(jac[domain.indexes[1]:domain.indexes[2],i])*R*T/P
+    end
+    @views @inbounds @fastmath jac[domain.indexes[3],domain.indexes[3]] = sum(jac[domain.indexes[1]:domain.indexes[2],domain.indexes[3]])*R*T/P
+          
+    @simd for ind in domain.constantspeciesinds
+        @inbounds jac[ind,:] .= 0.
+    end
+    
+    @simd for inter in interfaces
+        if isa(inter,Outlet) && domain == inter.domain
+            flow = inter.F(t)
+            @simd for i in domain.indexes[1]:domain.indexes[2]
+                @inbounds @fastmath jac[i,i] .-= flow/N
+            end
+            @views @inbounds @fastmath jac[domain.indexes[1]:domain.indexes[2],domain.indexes[3]] .-= flow.*ns.*(-C)
+        end
+    end
+end
+
 function getreactionindices(ig::Q) where {Q<:AbstractPhase}
     arr = zeros(Int64,(6,length(ig.reactions)))
     for (i,rxn) in enumerate(ig.reactions)

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -99,11 +99,12 @@ function ConstantTPDomain(;phase::E2,initialconds::Dict{X,X2},constantspecies::A
 end
 export ConstantTPDomain
 
-@with_kw struct ConstantVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
+@with_kw struct ConstantVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     V::W
+    efficiencyinds::Array{I,1}
     rxnarray::Array{Int64,2}
     jacobian::Array{W,2}
     sensitivity::Bool = false
@@ -152,6 +153,7 @@ function ConstantVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arra
     else
         constspcinds = Array{Int64,1}()
     end
+    efficiencyinds = [rxn.index for rxn in phase.reactions if typeof(rxn.kinetics)<:AbstractFalloffRate && length(rxn.kinetics.efficiencies) > 0]
     if sparse
         jacobian=zeros(typeof(T),length(phase.species)+2,length(phase.species)+2)
     else
@@ -159,15 +161,16 @@ function ConstantVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arra
     end
     rxnarray = getreactionindices(phase)
     return ConstantVDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1,phase.species[end].index+2),constspcinds,
-    V,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    V,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
 end
 export ConstantVDomain
 
-@with_kw struct ConstantPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
+@with_kw struct ConstantPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     P::W
+    efficiencyinds::Array{I,1}
     rxnarray::Array{Int64,2}
     jacobian::Array{W,2}
     sensitivity::Bool = false
@@ -216,6 +219,7 @@ function ConstantPDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arra
     else
         constspcinds = Array{Int64,1}()
     end
+    efficiencyinds = [rxn.index for rxn in phase.reactions if typeof(rxn.kinetics)<:AbstractFalloffRate && length(rxn.kinetics.efficiencies) > 0]
     if sparse
         jacobian=zeros(typeof(T),length(phase.species)+2,length(phase.species)+2)
     else
@@ -223,16 +227,17 @@ function ConstantPDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arra
     end
     rxnarray = getreactionindices(phase)
     return ConstantPDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1,phase.species[end].index+2),constspcinds,
-    P,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    P,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
 end
 export ConstantPDomain
 
-@with_kw struct ParametrizedTPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
+@with_kw struct ParametrizedTPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     T::Function
     P::Function
+    efficiencyinds::Array{I,1}
     rxnarray::Array{Int64,2}
     jacobian::Array{W,2}
     sensitivity::Bool = false
@@ -293,6 +298,7 @@ function ParametrizedTPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecie
     else
         constspcinds = Array{Int64,1}()
     end
+    efficiencyinds = [rxn.index for rxn in phase.reactions if typeof(rxn.kinetics)<:AbstractFalloffRate && length(rxn.kinetics.efficiencies) > 0]
     if sparse
         jacobian=zeros(typeof(V),length(phase.species)+1,length(phase.species)+1)
     else
@@ -300,15 +306,16 @@ function ParametrizedTPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecie
     end
     rxnarray = getreactionindices(phase)
     return ParametrizedTPDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1),constspcinds,
-    Tfcn,Pfcn,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    Tfcn,Pfcn,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
 end
 export ParametrizedTPDomain
 
-@with_kw struct ParametrizedVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
+@with_kw struct ParametrizedVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     V::Function
+    efficiencyinds::Array{I,1}
     rxnarray::Array{Int64,2}
     jacobian::Array{W,2}
     sensitivity::Bool = false
@@ -366,6 +373,7 @@ function ParametrizedVDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies
     else
         constspcinds = Array{Int64,1}()
     end
+    efficiencyinds = [rxn.index for rxn in phase.reactions if typeof(rxn.kinetics)<:AbstractFalloffRate && length(rxn.kinetics.efficiencies) > 0]
     if sparse
         jacobian=zeros(typeof(T),length(phase.species)+2,length(phase.species)+2)
     else
@@ -373,15 +381,16 @@ function ParametrizedVDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies
     end
     rxnarray = getreactionindices(phase)
     return ParametrizedVDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1,phase.species[end].index+2),constspcinds,
-    Vfcn,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    Vfcn,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
 end
 export ParametrizedVDomain
 
-@with_kw struct ParametrizedPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
+@with_kw struct ParametrizedPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     P::Function
+    efficiencyinds::Array{I,1}
     rxnarray::Array{Int64,2}
     jacobian::Array{W,2}
     sensitivity::Bool = false
@@ -439,6 +448,7 @@ function ParametrizedPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies
     else
         constspcinds = Array{Int64,1}()
     end
+    efficiencyinds = [rxn.index for rxn in phase.reactions if typeof(rxn.kinetics)<:AbstractFalloffRate && length(rxn.kinetics.efficiencies) > 0]
     if sparse
         jacobian=zeros(typeof(T),length(phase.species)+2,length(phase.species)+2)
     else
@@ -446,7 +456,7 @@ function ParametrizedPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies
     end
     rxnarray = getreactionindices(phase)
     return ParametrizedPDomain(phase,SVector(phase.species[1].index,phase.species[end].index,phase.species[end].index+1,phase.species[end].index+2),constspcinds,
-    Pfcn,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    Pfcn,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
 end
 export ParametrizedPDomain
 
@@ -530,12 +540,13 @@ function ConstantTVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arr
 end
 export ConstantTVDomain
 
-@with_kw struct ParametrizedTConstantVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,Q<:AbstractArray} <: AbstractVariableKDomain
+@with_kw struct ParametrizedTConstantVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray} <: AbstractVariableKDomain
     phase::N
     indexes::Q #assumed to be in ascending order
     constantspeciesinds::Array{S,1}
     T::Function
     V::W
+    efficiencyinds::Array{I,1}
     rxnarray::Array{Int64,2}
     jacobian::Array{W,2}
     sensitivity::Bool = false
@@ -585,6 +596,7 @@ function ParametrizedTConstantVDomain(;phase::IdealDiluteSolution,initialconds::
     else
         constspcinds = Array{Int64,1}()
     end
+    efficiencyinds = [rxn.index for rxn in phase.reactions if typeof(rxn.kinetics)<:AbstractFalloffRate && length(rxn.kinetics.efficiencies) > 0]
     if sparse
         jacobian=zeros(typeof(V),length(phase.species)+1,length(phase.species)+1)
     else
@@ -592,7 +604,7 @@ function ParametrizedTConstantVDomain(;phase::IdealDiluteSolution,initialconds::
     end
     rxnarray = getreactionindices(phase)
     return ParametrizedTConstantVDomain(phase,SVector(phase.species[1].index,phase.species[end].index),constspcinds,
-    Tfcn,V,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    Tfcn,V,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
 end
 export ParametrizedTConstantVDomain
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1217,7 +1217,6 @@ end
     V = y[d.indexes[3]]
     cs = ns./V
     C = N/V
-    P = C*R*T
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
     cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
@@ -1247,7 +1246,6 @@ end
     V = y[d.indexes[3]]
     cs = ns./V
     C = N/V
-    P = C*R*T
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
     cpdivR,hdivRT,sdivR = calcHSCpdless(d.phase.vecthermo,T)
@@ -1278,7 +1276,6 @@ end
     V = y[d.indexes[3]]
     cs = ns./V
     C = N/V
-    P = C*R*T
     Gs = zeros(length(d.phase.species))
     Us = zeros(length(d.phase.species))
     cpdivR,hdivRT1,sdivR = calcHSCpdless(d.phase.vecthermo,T)

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1833,6 +1833,57 @@ function jacobiany!(jac::Q,y::U,p::W,t::Z,domain::D,interfaces::Q3,colorvec::Q2=
     return jac
 end
 
+function jacobiany!(jac::Q,y::U,p::W,t::Z,domain::D,interfaces::Q3,colorvec::Q2=nothing) where {Q3<:AbstractArray,Q2,Q<:AbstractArray,U<:AbstractArray,W,Z<:Real,D<:ParametrizedPDomain}
+    ns,cs,T,P,V,C,N,mu,kfs,krevs,Hs,Us,Gs,diffs,Cvave,cpdivR = calcthermo(domain,y,t,p)
+    jacobianynsderiv!(jac,domain,domain.rxnarray,domain.efficiencyinds,cs,kfs,krevs,T,V,C)
+    
+    dydt = zeros(size(y))
+    addreactionratecontributions!(dydt,domain.rxnarray,cs,kfs,krevs)
+    dydt .*= V
+    
+    @fastmath Cpave = Cvave+R
+    dPdt = Calculus.derivative(domain.P,t)
+    @views @inbounds @fastmath dTdt = (-dot(Hs,dydt[domain.indexes[1]:domain.indexes[2]])+V*dPdt)/(N*Cpave)
+    @simd for i in domain.indexes[1]:domain.indexes[2]
+        @inbounds @fastmath dCpavedni = cpdivR[i]*R/N
+        @views @inbounds @fastmath jac[domain.indexes[3],i] = -dot(Hs,jac[domain.indexes[1]:domain.indexes[2],i])/(N*Cpave)-dTdt*(dCpavedni/Cpave)
+        @views @inbounds @fastmath jac[domain.indexes[4],i] = sum(jac[domain.indexes[1]:domain.indexes[2],i])*R*T/P + V/T*jac[domain.indexes[3],i]
+    end
+    @views @inbounds @fastmath jac[domain.indexes[3],domain.indexes[4]] = (-dot(Hs,jac[domain.indexes[1]:domain.indexes[2],domain.indexes[4]])+dPdt)/(N*Cpave)
+    @views @inbounds @fastmath jac[domain.indexes[4],domain.indexes[4]] = sum(jac[domain.indexes[1]:domain.indexes[2],domain.indexes[4]])*R*T/P + dTdt/T + V/T*jac[domain.indexes[3],domain.indexes[4]]-dPdt/P 
+    
+    @simd for ind in domain.constantspeciesinds
+        @inbounds jac[ind,:] .= 0.
+    end
+    
+    @simd for inter in interfaces
+        if isa(inter,Inlet) && domain == inter.domain
+            flow = inter.F(t)
+            @fastmath H = dot(Hs,ns)/N
+            @fastmath dTdt = flow*(inter.H - H)/(N*Cpave)
+            @simd for i in domain.indexes[1]:domain.indexes[2]
+                @inbounds @fastmath dCpavedni = cpdivR[i]*R/N
+                @inbounds @fastmath ddnidTdt = flow*(-Hs[i]/N)/(N*Cpave)-dTdt*(dCpavedni/Cpave)
+                @inbounds jac[domain.indexes[3],i] += ddnidTdt
+                @inbounds @fastmath jac[domain.indexes[4],i] += V/T*ddnidTdt
+            end
+            @fastmath ddVdTdt = -flow*H/V/(N*Cpave)
+            @inbounds jac[domain.indexes[3],domain.indexes[4]] += ddVdTdt
+            @inbounds @fastmath jac[domain.indexes[4],domain.indexes[4]] += dTdt/T + ddVdTdt*V/T
+        elseif isa(inter,Outlet) && domain == inter.domain
+            flow = inter.F(t)
+            @simd for i in domain.indexes[1]:domain.indexes[2]
+                @inbounds @fastmath jac[i,i] .-= flow/N
+            end
+            @views @inbounds @fastmath jac[domain.indexes[1]:domain.indexes[2],domain.indexes[4]] .-= -flow.*ns./N/V
+        end
+    end
+    
+    @inbounds jacobianytherm!(jac,y,p,t,domain,interfaces,domain.indexes[3],T,colorvec)
+    
+    return jac
+end
+
 function getreactionindices(ig::Q) where {Q<:AbstractPhase}
     arr = zeros(Int64,(6,length(ig.reactions)))
     for (i,rxn) in enumerate(ig.reactions)

--- a/src/PhaseState.jl
+++ b/src/PhaseState.jl
@@ -176,7 +176,6 @@ export getkfkrev
         krev = @fastmath kfs./getKcs(phase,T,Gs)
     elseif phase.diffusionlimited && !(kfs === nothing)
         len = length(phase.reactions)
-        kfs = zeros(typeof(N),len)
         krev = zeros(typeof(N),len)
         @simd for i = 1:len
            @fastmath @inbounds kfs[i],krev[i] = getkfkrev(phase.reactions[i],phase,T,P,C,N,ns,Gs,diffs,V;kf=kfs[i])

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -167,6 +167,149 @@ end
     end
 end
 
+@inline function _jacobianynswrtns!(jac::S,rxnarray::Array{Int64,2},rxnind::Int64,cs::Array{Float64,1},kf::Float64,krev::Float64) where {S<:AbstractArray}
+    k=kf
+    if rxnarray[2,rxnind] == 0
+        deriv = k
+        @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= deriv
+        @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
+    elseif rxnarray[3,rxnind] == 0
+        if rxnarray[1,rxnind] == rxnarray[2,rxnind]
+            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[1,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 2.0*deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
+        else
+            @inbounds @fastmath deriv = k*cs[rxnarray[2,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= deriv
+            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
+            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= deriv
+            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
+        end
+    else
+        if rxnarray[1,rxnind]==rxnarray[2,rxnind] && rxnarray[1,rxnind]==rxnarray[3,rxnind]
+            @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 3.0*deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
+        elseif rxnarray[1,rxnind]==rxnarray[2,rxnind]
+            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[3,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 2.0*deriv
+            @inbounds jac[rxnarray[3,rxnind],rxnarray[1,rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
+            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[3,rxnind]] -= 2.0*deriv
+            @inbounds jac[rxnarray[3,rxnind],rxnarray[3,rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[3,rxnind])
+        elseif rxnarray[2,rxnind]==rxnarray[3,rxnind]
+            @inbounds @fastmath deriv = k*cs[rxnarray[2,rxnind]]*cs[rxnarray[2,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= deriv
+            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= 2.0*deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
+            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= deriv
+            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= 2.0*deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
+        elseif rxnarray[1,rxnind]==rxnarray[3,rxnind]
+            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 2.0*deriv
+            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
+            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= 2.0*deriv
+            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
+        else
+            @inbounds @fastmath deriv = k*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= deriv
+            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= deriv
+            @inbounds jac[rxnarray[3,rxnind],rxnarray[1,rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
+            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[3,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= deriv
+            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= deriv
+            @inbounds jac[rxnarray[3,rxnind],rxnarray[2,rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
+            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]
+            @inbounds jac[rxnarray[1,rxnind],rxnarray[3,rxnind]] -= deriv
+            @inbounds jac[rxnarray[2,rxnind],rxnarray[3,rxnind]] -= deriv
+            @inbounds jac[rxnarray[3,rxnind],rxnarray[3,rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[3,rxnind])
+        end
+    end
+    k=krev
+    if rxnarray[5,rxnind] == 0
+        deriv = k
+        @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= deriv
+        @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
+    elseif rxnarray[6,rxnind] == 0
+        if rxnarray[4,rxnind] == rxnarray[5,rxnind]
+            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[4,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= 2.0*deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
+        else
+            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= deriv
+            @inbounds jac[rxnarray[5,rxnind],rxnarray[4,rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
+            @inbounds @fastmath deriv = k*cs[rxnarray[4,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[5,rxnind]] -= deriv
+            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
+        end
+    else
+        if rxnarray[4,rxnind]==rxnarray[5,rxnind] && rxnarray[4,rxnind]==rxnarray[6,rxnind]
+            @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[4,rxnind]]*cs[rxnarray[4,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= 3.0*deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
+        elseif rxnarray[4,rxnind]==rxnarray[5,rxnind]
+            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[4,rxnind]]*cs[rxnarray[6,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= 2.0*deriv
+            @inbounds jac[rxnarray[6,rxnind],rxnarray[4,rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
+            @inbounds @fastmath deriv = k*cs[rxnarray[4,rxnind]]*cs[rxnarray[4,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[6,rxnind]] -= 2.0*deriv
+            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
+        elseif rxnarray[5,rxnind]==rxnarray[6,rxnind]
+            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= deriv
+            @inbounds jac[rxnarray[5,rxnind],rxnarray[4,rxnind]] -= 2.0*deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
+            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[4,rxnind]]*cs[rxnarray[5,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[5,rxnind]] -= deriv
+            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
+        elseif rxnarray[4,rxnind]==rxnarray[6,rxnind]
+            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[4,rxnind]]*cs[rxnarray[5,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= 2.0*deriv
+            @inbounds jac[rxnarray[5,rxnind],rxnarray[4,rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
+            @inbounds @fastmath deriv = k*cs[rxnarray[4,rxnind]]*cs[rxnarray[4,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
+            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
+        else
+            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= deriv
+            @inbounds jac[rxnarray[5,rxnind],rxnarray[4,rxnind]] -= deriv
+            @inbounds jac[rxnarray[6,rxnind],rxnarray[4,rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
+            @inbounds @fastmath deriv = k*cs[rxnarray[4,rxnind]]*cs[rxnarray[6,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[5,rxnind]] -= deriv
+            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
+            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
+            @inbounds @fastmath deriv = k*cs[rxnarray[4,rxnind]]*cs[rxnarray[5,rxnind]]
+            @inbounds jac[rxnarray[4,rxnind],rxnarray[6,rxnind]] -= deriv
+            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= deriv
+            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
+        end
+    end
+end
+
 # function jacobianp!(d::W;cs::Q,V::Y,T::Y2,Us::Z3,Cvave::Z4,N::Z5,kfs::Z,krevs::X,wV::Q2,ratederiv::Q3) where {Q3,W<:Union{ConstantTPDomain,ConstantTVDomain},Z4<:Real,Z5<:Real,Z3<:AbstractArray,Q2<:AbstractArray,Q<:AbstractArray,Y2<:Real,Y<:Real,Z<:AbstractArray,X<:AbstractArray}
 #     Nspcs = length(cs)
 #     rxns = d.phase.reactions

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -310,6 +310,39 @@ end
     end
 end
 
+@inline function _jacobianynswrtV!(jac::S,Vind::Int64,rxnarray::Array{Int64,2},rxnind::Int64,cs::Array{Float64,1},kf::Float64,krev::Float64) where {S<:AbstractArray}
+    k=kf
+    if rxnarray[2,rxnind]==0
+        nothing
+    elseif rxnarray[3,rxnind]== 0
+        @inbounds @fastmath deriv = -k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]
+        @inbounds jac[rxnarray[1,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[2,rxnind],Vind] -= deriv
+        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,Vind)
+    else
+        @inbounds @fastmath deriv = -2.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]
+        @inbounds jac[rxnarray[1,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[2,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[3,rxnind],Vind] -= deriv
+        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,Vind)
+    end
+    k=krev
+    if rxnarray[5,rxnind]==0
+        nothing
+    elseif rxnarray[6,rxnind] == 0
+        @inbounds @fastmath deriv = -k*cs[rxnarray[4,rxnind]]*cs[rxnarray[5,rxnind]]
+        @inbounds jac[rxnarray[4,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[5,rxnind],Vind] -= deriv
+        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,Vind)
+    else
+        @inbounds @fastmath deriv = -2.0*k*cs[rxnarray[4,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
+        @inbounds jac[rxnarray[4,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[5,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[6,rxnind],Vind] -= deriv
+        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,Vind)
+    end
+end
+
 # function jacobianp!(d::W;cs::Q,V::Y,T::Y2,Us::Z3,Cvave::Z4,N::Z5,kfs::Z,krevs::X,wV::Q2,ratederiv::Q3) where {Q3,W<:Union{ConstantTPDomain,ConstantTVDomain},Z4<:Real,Z5<:Real,Z3<:AbstractArray,Q2<:AbstractArray,Q<:AbstractArray,Y2<:Real,Y<:Real,Z<:AbstractArray,X<:AbstractArray}
 #     Nspcs = length(cs)
 #     rxns = d.phase.reactions

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -93,7 +93,7 @@ export addreactionratecontributions!
 
 @inline function dydtreactor!(dydt::RC,y::U,t::Z,domain::Q,interfaces::B;p::RV=DiffEqBase.NullParameters(),sensitivity::Bool=true) where {RC,RV,B<:AbstractArray,Z<:Real,U,J<:Integer,Q<:AbstractDomain}    
     dydt .= 0.0
-    ns,cs,T,P,V,C,N,mu,kfs,krevs,Hs,Us,Gs,diffs,Cvave = calcthermo(domain,y,t,p)
+    ns,cs,T,P,V,C,N,mu,kfs,krevs,Hs,Us,Gs,diffs,Cvave,cpdivR = calcthermo(domain,y,t,p)
     addreactionratecontributions!(dydt,domain.rxnarray,cs,kfs,krevs)
     dydt .*= V
     calcdomainderivatives!(domain,dydt,interfaces;t=t,T=T,P=P,Us=Us,Hs=Hs,V=V,C=C,ns=ns,N=N,Cvave=Cvave)

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -343,6 +343,46 @@ end
     end
 end
 
+"""
+This function calculates the ns partials in jacobiany involving k derivatives. dkdx is either dkdni and dkdV. x is either ni or V.
+"""
+@inline function _jacobianykderiv!(jac::S,xind::Int64,dkfdx::Float64,dkrevdx::Float64,rxnarray::Array{Int64,2},rxnind::Int64,cs::Array{Float64,1},V::Float64) where {S<:AbstractArray}
+    dkdx = dkfdx
+    if rxnarray[2,rxnind] == 0
+        @inbounds @fastmath deriv = dkdx*cs[rxnarray[1,rxnind]]*V
+        @inbounds jac[rxnarray[1,rxnind],xind] -= deriv
+        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,xind)
+    elseif rxnarray[3,rxnind] == 0
+        @inbounds @fastmath deriv = dkdx*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*V
+        @inbounds jac[rxnarray[1,rxnind],xind] -= deriv
+        @inbounds jac[rxnarray[2,rxnind],xind] -= deriv
+        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,xind)
+    else
+        @inbounds @fastmath deriv = dkdx*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*V
+        @inbounds jac[rxnarray[1,rxnind],xind] -= deriv
+        @inbounds jac[rxnarray[2,rxnind],xind] -= deriv
+        @inbounds jac[rxnarray[3,rxnind],xind] -= deriv
+        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,xind)
+    end
+    dkdx = dkrevdx
+    if rxnarray[5,rxnind] == 0
+        @inbounds @fastmath deriv = dkdx*cs[rxnarray[4,rxnind]]*V
+        @inbounds jac[rxnarray[4,rxnind],xind] -= deriv
+        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,xind)
+    elseif rxnarray[6,rxnind] == 0
+        @inbounds @fastmath deriv = dkdx*cs[rxnarray[4,rxnind]]*cs[rxnarray[5,rxnind]]*V
+        @inbounds jac[rxnarray[4,rxnind],xind] -= deriv
+        @inbounds jac[rxnarray[5,rxnind],xind] -= deriv
+        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,xind)
+    else
+        @inbounds @fastmath deriv = dkdx*cs[rxnarray[4,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*V
+        @inbounds jac[rxnarray[4,rxnind],xind] -= deriv
+        @inbounds jac[rxnarray[5,rxnind],xind] -= deriv
+        @inbounds jac[rxnarray[6,rxnind],xind] -= deriv
+        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,xind)
+    end
+end
+
 # function jacobianp!(d::W;cs::Q,V::Y,T::Y2,Us::Z3,Cvave::Z4,N::Z5,kfs::Z,krevs::X,wV::Q2,ratederiv::Q3) where {Q3,W<:Union{ConstantTPDomain,ConstantTVDomain},Z4<:Real,Z5<:Real,Z3<:AbstractArray,Q2<:AbstractArray,Q<:AbstractArray,Y2<:Real,Y<:Real,Z<:AbstractArray,X<:AbstractArray}
 #     Nspcs = length(cs)
 #     rxns = d.phase.reactions

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -101,10 +101,19 @@ export addreactionratecontributions!
 end
 export dydtreactor!
 
-function jacobiany!(J::Q,y::U,p::W,t::Z,domain::V,interfaces::Q3,colorvec::Q2=nothing) where {Q3<:AbstractArray,Q2,Q<:AbstractArray,U<:AbstractArray,W,Z<:Real,V<:AbstractDomain}
+function jacobianyforwarddiff!(J::Q,y::U,p::W,t::Z,domain::V,interfaces::Q3,colorvec::Q2=nothing) where {Q3<:AbstractArray,Q2,Q<:AbstractArray,U<:AbstractArray,W,Z<:Real,V<:AbstractDomain}
     f(dy::X,y::Array{T,1}) where {T<:Real,X} = dydtreactor!(dy,y,t,domain,interfaces;p=p,sensitivity=false)
     ForwardDiff.jacobian!(J,f,zeros(size(y)),y)
 end
+export jacobianyforwarddiff!
+
+function jacobianyforwarddiff(y::U,p::W,t::Z,domain::V,interfaces::Q3,colorvec::Q2=nothing) where {Q3<:AbstractArray,Q2,U<:AbstractArray,W,Z<:Real,V<:AbstractDomain}
+    J = zeros(length(y),length(y))
+    jacobianyforwarddiff!(J,y,p,t,domain,interfaces,colorvec)
+    return J
+end
+export jacobianyforwarddiff
+
 # function jacobiany!(J::Q,y::U,p::W,t::Z,domain::V,interfaces::Q3,colorvec::Q2=nothing) where {Q3<:AbstractArray,Q2<:AbstractArray,Q<:AbstractArray,U<:AbstractArray,W,Z<:Real,V<:AbstractDomain}
 #     f(y::Array{T,1}) where {T<:Real} = dydtreactor!(y,t,domain,interfaces;p=p,sensitivity=false)
 #     forwarddiff_color_jacobian!(J,f,y,colorvec=colorvec)
@@ -1022,4 +1031,3 @@ end
 #     end
 #     return jac
 # end
-export jacobiany!

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -148,6 +148,25 @@ function jacobianp(y::U,p::W,t::Z,domain::V,interfaces::Q3,colorvec::Q2=nothing)
 end
 export jacobianp
 
+@inline function _spreadreactantpartials!(jac::S,deriv::Float64,rxnarray::Array{Int64,2},rxnind::Int64,ind::Int64) where {S<:AbstractArray}
+    jac[rxnarray[4,rxnind],ind] += deriv
+    if rxnarray[5,rxnind] !== 0
+        jac[rxnarray[5,rxnind],ind] += deriv
+        if rxnarray[6,rxnind] !== 0
+            jac[rxnarray[6,rxnind],ind] += deriv
+        end
+    end
+end
+@inline function _spreadproductpartials!(jac::S,deriv::Float64,rxnarray::Array{Int64,2},rxnind::Int64,ind::Int64) where {S<:AbstractArray}
+    jac[rxnarray[1,rxnind],ind] += deriv
+    if rxnarray[2,rxnind] !== 0
+        jac[rxnarray[2,rxnind],ind] += deriv
+        if rxnarray[3,rxnind] !== 0
+            jac[rxnarray[3,rxnind],ind] += deriv
+        end
+    end
+end
+
 # function jacobianp!(d::W;cs::Q,V::Y,T::Y2,Us::Z3,Cvave::Z4,N::Z5,kfs::Z,krevs::X,wV::Q2,ratederiv::Q3) where {Q3,W<:Union{ConstantTPDomain,ConstantTVDomain},Z4<:Real,Z5<:Real,Z3<:AbstractArray,Q2<:AbstractArray,Q<:AbstractArray,Y2<:Real,Y<:Real,Z<:AbstractArray,X<:AbstractArray}
 #     Nspcs = length(cs)
 #     rxns = d.phase.reactions

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -383,6 +383,16 @@ This function calculates the ns partials in jacobiany involving k derivatives. d
     end
 end
 
+function _dydttherm(dy::X,x::T,y::Q,p::W,t::Z,domain::D,interfaces::Q3,ind::T1) where {X,Q3<:AbstractArray,T<:Real,Q<:AbstractArray,Z<:Real,D<:AbstractDomain,T1<:Integer,W}
+    v = [ i != ind ? convert(typeof(x),z) : x for (i,z) in enumerate(y)]
+    return dydtreactor!(dy,v,t,domain,interfaces;p=p,sensitivity=false)
+end
+
+function jacobianytherm!(jac::Q,y::U,p::W,t::Z,domain::D,interfaces::Q3,ind::I,x::F,colorvec::Q2=nothing) where {Q3<:AbstractArray,Q2,Q<:AbstractArray,U<:AbstractArray,W,Z<:Real,D<:AbstractDomain,I<:Int64,F<:Float64}
+    f(dy::X,x::Y) where {Y<:Real,X} = _dydttherm(dy,x,y,p,t,domain,interfaces,ind)
+    jac[:,ind] = ForwardDiff.derivative(f,zeros(size(y)),x)
+end
+
 # function jacobianp!(d::W;cs::Q,V::Y,T::Y2,Us::Z3,Cvave::Z4,N::Z5,kfs::Z,krevs::X,wV::Q2,ratederiv::Q3) where {Q3,W<:Union{ConstantTPDomain,ConstantTVDomain},Z4<:Real,Z5<:Real,Z3<:AbstractArray,Q2<:AbstractArray,Q<:AbstractArray,Y2<:Real,Y<:Real,Z<:AbstractArray,X<:AbstractArray}
 #     Nspcs = length(cs)
 #     rxns = d.phase.reactions

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -127,8 +127,8 @@ this assumes no changes in code branching during simulation, if that were to bec
 based alternative algorithm is slower, but avoids this concern. 
 """
 function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)),abstol::Float64=1e-6,reltol::Float64=1e-3,kwargs...) where {Q,W,W2}
-    @assert target in bsol.names || target in ["T","V"]
-    if target in ["T","V"]
+    @assert target in bsol.names || target in ["T","V","P"]
+    if target in ["T","V","P"]
         ind = bsol.domain.indexes[end]
     else
         ind = findfirst(isequal(target),bsol.names)
@@ -149,7 +149,7 @@ function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=In
     dgdp(out, y, p, t) = ForwardDiff.gradient!(out, p -> g(y, p, t), p)
     du0,dpadj = adjoint_sensitivities(bsol.sol,solver,g,nothing,(dgdu,dgdp);sensealg=sensalg,abstol=abstol,reltol=reltol,kwargs...)
     dpadj[length(bsol.domain.phase.species)+1:end] .*= bsol.domain.p[length(bsol.domain.phase.species)+1:end]
-    if !(target in ["T","V"])
+    if !(target in ["T","V","P"])
         dpadj ./= bsol.sol(bsol.sol.t[end])[ind]
     end
     return dpadj

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -129,7 +129,7 @@ based alternative algorithm is slower, but avoids this concern.
 function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)),abstol::Float64=1e-6,reltol::Float64=1e-3,kwargs...) where {Q,W,W2}
     @assert target in bsol.names || target in ["T","V","P"]
     if target in ["T","V","P"]
-        ind = bsol.domain.indexes[end]
+        ind = getthermovariableindex(bsol.domain,target)
     else
         ind = findfirst(isequal(target),bsol.names)
     end

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -22,6 +22,13 @@ spcnames = getfield.(liq.species,:name)
 octaneind = findfirst(isequal("octane"),spcnames)
 y = sol(32977.61568)
 @test y[octaneind]/sum(y) ≈ 0.461599061 rtol=3e-2 #from RMG simulator I believe the slight difference is due to better calculation of diffusion limits in RMS
+
+#analytic jacobian vs. ForwardDiff jacobian
+t=32977.61568;
+y=sol(t)
+ja=jacobiany(y,p,t,domain,[],nothing);
+j=jacobianyforwarddiff(y,p,t,domain,[],nothing);
+@test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
 end;
 
 #Use superminimal example to test

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -81,9 +81,9 @@ j = jacobianyforwarddiff(y,p,t,domain,[],nothing);
 @test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
 
 #sensitivities
-dps = getadjointsensitivities(sim,"H2",CVODE_BDF();sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)),abstol=1e-16,reltol=1e-6)
+dps = getadjointsensitivities(sim,"H2",CVODE_BDF(linear_solver=:GMRES);sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)),abstol=1e-16,reltol=1e-6)
 react2 = Reactor(domain,y0,(0.0,150.11094);p=p,forwardsensitivities=true)
-sol2 = solve(react2.ode,CVODE_BDF(),abstol=1e-20,reltol=1e-6); #solve the ode associated with the reactor
+sol2 = solve(react2.ode,CVODE_BDF(linear_solver=:GMRES),abstol=1e-21,reltol=1e-7); #solve the ode associated with the reactor
 sim2 = Simulation(sol2,domain)
 
 x,dp = extract_local_sensitivities(sol2,150.11094);
@@ -93,7 +93,7 @@ dpvs[length(domain.phase.species)+1:end] .*= domain.p[length(domain.phase.specie
 dpvs ./= sol2(150.11094)[ind]
 rerr = (dpvs .- dps')./dpvs
 rerr = [isinf(x) ? 0.0 : x for x in rerr]
-@test all((abs.(rerr) .> 1e-2).==false)
+@test all((abs.(rerr) .> 1e-1).==false)
 end;
 
 #Constant V adiabatic Ideal Gas

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -109,6 +109,13 @@ ts = exp.(range(log(1e-15),length=10000,stop=log(0.1)))
 IDT = ts[argmax(diff([sol(t)[end] for t in ts]))] #Ignition Delay Time based on argmax(dTdt(t))
 
 @test IDT ≈ 0.038384723436228063 rtol=1e-5 #from Cantera simulation
+
+#analytic jacobian vs. ForwardDiff jacobian
+t=0.01;
+y = sol(t);
+ja=jacobiany(y,p,t,domain,[],nothing);
+j = jacobianyforwarddiff(y,p,t,domain,[],nothing);
+@test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
 end;
 
 #Constant P adiabatic Ideal Gas

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -3,13 +3,15 @@ using DiffEqBase
 using Sundials
 
 @testset "Test Reactors" begin
-@testset "Test liquid phase reactor simulation" begin
-#Constant T and V Ideal Dilute Liquid
+
 phaseDict = readinput("../src/testing/liquid_phase.rms")
 spcs = phaseDict["phase"]["Species"]; #mechanism dictionaries index:  phaseDict[phasename]["Species" or "Reactions"]
 rxns = phaseDict["phase"]["Reactions"];
 solv = phaseDict["Solvents"][1];
 liq = IdealDiluteSolution(spcs,rxns,solv;name="phase",diffusionlimited=true) #Define the phase (how species thermodynamic and kinetic properties calculated)
+
+@testset "Test liquid phase Constant T Constant V reactor simulation" begin
+#Constant T and V Ideal Dilute Liquid
 initialconds = Dict(["T"=>450.0,"V"=>1.0e-6*1e6,"octane"=>6.154e-3*1e6,"oxygen"=>4.953e-6*1e6]) #Set simulation Initial Temp and Pressure
 domain,y0,p = ConstantTVDomain(phase=liq,initialconds=initialconds,constantspecies=["oxygen"]) #Define the domain (encodes how system thermodynamic properties calculated)
 react = Reactor(domain,y0,(0.0,140000.01);p=p) #Create the reactor object

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -137,6 +137,14 @@ ts = exp.(range(log(1e-15),length=10000,stop=log(0.2)))
 IDT = ts[argmax(diff([sol(t)[end] for t in ts]))] #Ignition Delay Time based on argmax(dTdt(t))
 
 @test IDT ≈ 0.07324954954380769 rtol=1e-5
+
+#analytic jacobian vs. ForwardDiff jacobian
+t=0.01;
+y=sol(t)
+ja=jacobiany(y,p,t,domain,[],nothing);
+j = jacobianyforwarddiff(y,p,t,domain,[],nothing);
+@test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
+
 end;
 
 end;

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -73,6 +73,13 @@ N = sim.N(20.44002454)
 @test y[o2ind]/N ≈ 0.200419093 rtol=1e-4
 @test y[h2oind]/N ≈ 0.386618602 rtol=1e-4
 
+#analytic jacobian vs. ForwardDiff jacobian
+t=20.44002454;
+y=sol(t)
+ja=jacobiany(y,p,t,domain,[],nothing);
+j = jacobianyforwarddiff(y,p,t,domain,[],nothing);
+@test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
+
 #sensitivities
 dps = getadjointsensitivities(sim,"H2",CVODE_BDF();sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)),abstol=1e-16,reltol=1e-6)
 react2 = Reactor(domain,y0,(0.0,150.11094);p=p,forwardsensitivities=true)

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -147,4 +147,19 @@ j = jacobianyforwarddiff(y,p,t,domain,[],nothing);
 
 end;
 
+#Parametrized T and P Ideal Gas
+#uses superminimal.yml mechanism
+@testset "Parametrized T and P reactor jacobian" begin
+initialconds = Dict(["T"=>[1000.0,1400.0,1500.0],"ts"=>[0.,100.,200.],"P"=>[1.0e5,1.8e5,2.0e5],"H2"=>0.67,"O2"=>0.33]) #Set simulation Initial Temp/Pressure and Volume (function/array)
+domain,y0,p = ParametrizedTPDomain(phase=ig,initialconds=initialconds) #Define the domain (encodes how system thermodynamic properties calculated)
+
+react = Reactor(domain,y0,(0.0,0.101),p=p) #Create the reactor object
+sol = solve(react.ode,CVODE_BDF(),abstol=1e-20,reltol=1e-12); #solve the ode associated with the reactor
+
+#analytic jacobian vs. ForwardDiff jacobian
+t=0.1;
+y = sol(t);
+ja=jacobiany(y,p,t,domain,[],nothing);
+j = jacobianyforwarddiff(y,p,t,domain,[],nothing);
+@test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
 end;

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -180,3 +180,24 @@ ja=jacobiany(y,p,t,domain,[],nothing);
 j = jacobianyforwarddiff(y,p,t,domain,[],nothing);
 @test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
 end;
+
+#Parametrized P adiabatic Ideal Gas
+#uses ethane.yml mechanism
+@testset "Parametrized pressure adiabatic reactor jacobian" begin
+initialconds = Dict(["T"=>1000.0,"ts"=>[0.,100.,200.],"P"=>[2.0e5,3.0e5,5.0e5],"H2"=>0.67,"O2"=>0.33])
+domain,y0,p = ParametrizedPDomain(phase=ig,initialconds=initialconds) #Define the domain (encodes how system thermodynamic properties calculated)
+
+react = Reactor(domain,y0,(0.0,0.101),p=p) #Create the reactor object
+sol = solve(react.ode,CVODE_BDF(),abstol=1e-20,reltol=1e-12); #solve the ode associated with the reactor
+
+#analytic jacobian vs. ForwardDiff jacobian
+t=0.1;
+y = sol(t);
+ja=jacobiany(y,p,t,domain,[],nothing);
+j = jacobianyforwarddiff(y,p,t,domain,[],nothing);
+@test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
+end;
+
+
+
+end;

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -163,3 +163,20 @@ ja=jacobiany(y,p,t,domain,[],nothing);
 j = jacobianyforwarddiff(y,p,t,domain,[],nothing);
 @test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
 end;
+
+#Parametrized V adiabatic Ideal Gas
+#uses superminimal.yml mechanism
+@testset "Parametrized volume adiabatic reactor jacobian" begin
+initialconds = Dict(["T"=>1000.0,"ts"=>[0.,100.,200.],"V"=>[0.01,0.05,0.1],"H2"=>0.67,"O2"=>0.33]) #Set simulation Initial Temp/Pressure and Volume (function/array)
+domain,y0,p = ParametrizedVDomain(phase=ig,initialconds=initialconds) #Define the domain (encodes how system thermodynamic properties calculated)
+
+react = Reactor(domain,y0,(0.0,0.101),p=p) #Create the reactor object
+sol = solve(react.ode,CVODE_BDF(),abstol=1e-20,reltol=1e-12); #solve the ode associated with the reactor
+
+#analytic jacobian vs. ForwardDiff jacobian
+t=0.1;
+y = sol(t);
+ja=jacobiany(y,p,t,domain,[],nothing);
+j = jacobianyforwarddiff(y,p,t,domain,[],nothing);
+@test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
+end;

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -31,6 +31,22 @@ j=jacobianyforwarddiff(y,p,t,domain,[],nothing);
 @test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
 end;
 
+@testset "Test liquid phase Parametrized T Constant V reactor jacobian" begin
+#Parametrized T constant V Ideal Dilute Liquid
+initialconds = Dict(["ts"=>[0.,600.,1200.],"T"=>[450.0,490.,500.],"V"=>1.0e-6*1e6,"octane"=>6.154e-3*1e6,"oxygen"=>4.953e-6*1e6])
+domain,y0,p = ParametrizedTConstantVDomain(phase=liq,initialconds=initialconds) #Define the domain (encodes how system thermodynamic properties calculated)
+
+react = Reactor(domain,y0,(0.0,140000.01),p=p) #Create the reactor object
+sol = solve(react.ode,CVODE_BDF(),abstol=1e-20,reltol=1e-8); #solve the ode associated with the reactor
+
+#analytic jacobian vs. ForwardDiff jacobian
+t=32977.61568;
+y=sol(t)
+ja=jacobiany(y,p,t,domain,[],nothing);
+j=jacobianyforwarddiff(y,p,t,domain,[],nothing);
+@test all((abs.(ja.-j) .> 1e-4.*abs.(j).+1e-16).==false)
+end;
+
 #Use superminimal example to test
 phaseDict = readinput("../src/testing/superminimal.rms") #load mechanism dictionary
 spcs = phaseDict["phase"]["Species"]; #mechanism dictionaries index:  phaseDict[phasename]["Species" or "Reactions"]


### PR DESCRIPTION
This PR enables calculating analytic jacobian for individual domains, with the exception that the partials with respect to thermodynamic variables are calculated using forward automatic differentiation. See #55. 

This PR also changes the p in ConstantTVDomain to store non-diffusion-limited forward reaction rates (kfsnondiff), instead of storing diffusion-limited (kfs). This helps to obtain correct diffusion-limited reverse reaction rates (krevs).
