### PR TITLE
Use build file to ensure python3.7

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,12 @@
+using PyCall
+if PyCall.pyversion.major != 3 || PyCall.pyversion.minor != 7
+    using Conda
+    const Pkg = Base.require(Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg"))
+    Conda.add("python=3.7")
+    Conda.rm("numpy") #get around MKL problem
+    Conda.add("nomkl")
+    Conda.add("numpy")
+    Conda.add_channel("rmg")
+    Conda.add("rmg")
+    Pkg.build("PyCall")
+end

--- a/src/ReactionMechanismSimulator.jl
+++ b/src/ReactionMechanismSimulator.jl
@@ -1,11 +1,5 @@
 module ReactionMechanismSimulator
     using PyCall
-    if PyCall.pyversion.major != 3 || PyCall.pyversion.minor != 7
-        using Conda
-        using Pkg
-        Conda.add("python==3.7")
-        Pkg.build("PyCall")
-    end
     push!(PyVector(pyimport("sys")["path"]), "")
     const Chem = PyNULL()
     const molecule = PyNULL()


### PR DESCRIPTION
Changing conda to python 3.7 seems to generally lead to an issue with conflicts between the julia and conda versions of mkl for this reason we uninstall numpy and install nomkl so that the python packages don’t try to install mkl. This commit should make RMS install-able straight from Pkg. 