### PR TITLE
Fix pyrms issue with kinetics vectorization

### DIFF
--- a/src/Phase.jl
+++ b/src/Phase.jl
@@ -150,9 +150,9 @@ function getveckinetics(rxns)
     otherrxninds = Array{Int64,1}()
     for (i,tp) in enumerate(tps)
         if typeof(tp)<:Tuple
-            typ = tp[1]
+            typ = split(tp[1],".")[end] #this split needs done because in pyrms the type names come as ReactionMechanismSimulator.Arrhenius instead of Arrhenius in RMS proper
         else
-            typ = tp
+            typ = split(tp,".")[end]
         end
         rinds = [findfirst(isequal(rxn),rxns) for rxn in rxnlists[i]]
         fcn = Symbol(typ * "vec")


### PR DESCRIPTION
In pyrms typeof(kinetics).name comes out as ReactionMechanismSimulator.Arrhenius instead of just Arrhenius this causes it to think it can't vectorize any kinetics significantly slowing it down relative to RMS proper. This commit causes RMS to remove the ReactionMechanismSimulator part from the type string if it is present. This makes pyrms just as fast as RMS proper. 