### PR TITLE
Fix issue with adjoint sensitivities for domains where rate coefficients vary

### DIFF
--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -138,7 +138,7 @@ By default uses the InterpolatingAdjoint algorithm with vector Jacobian products
 this assumes no changes in code branching during simulation, if that were to become no longer true, the Tracker 
 based alternative algorithm is slower, but avoids this concern. 
 """
-function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)),abstol::Float64=1e-6,reltol::Float64=1e-3,kwargs...) where {Q,W,W2}
+function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(false)),abstol::Float64=1e-6,reltol::Float64=1e-3,kwargs...) where {Q,W,W2}
     @assert target in bsol.names || target in ["T","V","P"]
     if target in ["T","V","P"]
         ind = getthermovariableindex(bsol.domain,target)


### PR DESCRIPTION
So I'm no longer able to reproduce the issue I had originally where using ReverseDiffVJP(false) gave NaNs forcing us to use ReverseDiffVJP(true) (which assumes no programmatic branching in the code, which should be true for domains with constant rate coefficients, but often not true for other domains) see #84 . I'm not entirely sure if this is something we fixed internally while working on something separate or it's related to package versioning. If the issue does up later we should be able to resolve it by adjusting our compat requirements. This PR switches us to default ReverseDiffVJP(false) and adds a test for adjoint and forward sensitivities for the ConstantVDomain. 