### PR TITLE
Speed up Adjoint Sensitivities

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -2,7 +2,6 @@ using Parameters
 using LinearAlgebra
 using StaticArrays
 using Calculus
-using SmoothingSplines
 using DiffEqBase
 using ForwardDiff
 using Tracker
@@ -2306,12 +2305,3 @@ function getreactionindices(ig::Q) where {Q<:AbstractPhase}
     return arr
 end
 export getreactionindices
-
-"""
-fit a cubic spline to data and return a function evaluating that spline
-"""
-function getspline(xs,vals;s=1e-10)
-    smspl = fit(SmoothingSpline,xs,vals,s)
-    F(x::T) where {T} = predict(smspl,x)
-    return F
-end

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -2315,23 +2315,3 @@ function getspline(xs,vals;s=1e-10)
     F(x::T) where {T} = predict(smspl,x)
     return F
 end
-
-function getthermovariableindex(domain::Union{ConstantTPDomain,ParametrizedTPDomain},target::String)
-    return domain.indexes[3]
-end
-
-function getthermovariableindex(domain::Union{ConstantVDomain,ParametrizedVDomain},target::String)
-    if target == "T"
-        return domain.indexes[3]
-    elseif target == "P"
-        return domain.indexes[4]
-    end
-end
-
-function getthermovariableindex(domain::Union{ConstantPDomain,ParametrizedPDomain},target::String)
-    if target == "T"
-        return domain.indexes[3]
-    elseif target == "V"
-        return domain.indexes[4]
-    end
-end

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -2375,3 +2375,24 @@ export getreactionindices
     
     return sensspcs,sensrxns,sensspcnames,senstooriginspcind,senstooriginrxnind
 end
+
+@inline function getsensdomain(domain::D,ind::Int64) where {D<:AbstractDomain}
+    
+    sensspcs,sensrxns,sensspcnames,senstooriginspcind,senstooriginrxnind = getsensspcsrxns(domain,ind)
+    
+    initialconds = Dict{String,Float64}()
+
+    for fn in fieldnames(typeof(domain))
+        if fn in (:T, :P, :V)
+            initialconds["$fn"] = getfield(domain,fn)
+        end
+    end
+    
+    d = Symbol(split(repr(typeof(domain)),"{")[1])
+
+    if isa(domain.phase,IdealGas)
+        return eval(d)(phase=IdealGas(sensspcs,sensrxns,name="phase"),initialconds=initialconds)[1],sensspcnames,senstooriginspcind,senstooriginrxnind
+    else
+        return eval(d)(phase=IdealDiluteSolution(sensspcs,sensrxns,domain.phase.solvent,name="phase"),initialconds=initialconds)[1],sensspcnames,senstooriginspcind,senstooriginrxnind
+    end
+end

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -742,7 +742,7 @@ end
         else
             d.Gs = d.p[1:length(d.phase.species)].+p[d.parameterindexes[1]-1+1:d.parameterindexes[1]-1+length(d.phase.species)]
         end
-        krevs = getkfkrevs(d.phase,d.T,d.P,C,N,ns,d.Gs,d.diffusivity,V=V;kfs=d.kfs)[2]
+        krevs = getkfkrevs(d.phase,d.T,d.P,C,N,ns,d.Gs,d.diffusivity,V;kfs=d.kfs)[2]
         for ind in d.efficiencyinds #efficiency related rates may have changed
             d.kfs[ind],d.krevs[ind] = getkfkrev(d.phase.reactions[ind],d.phase,d.T,d.P,C,N,ns,d.Gs,d.diffusivity,V;f=kfps[ind])
         end

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -686,7 +686,7 @@ function ConstantTADomain(;phase::E2,initialconds::Dict{X,X2},constantspecies::A
     end
     rxnarray = getreactionindices(phase)
     return ConstantTADomain(phase,[phase.species[1].index,phase.species[end].index],[1,length(phase.species)+length(phase.reactions)],constspcinds,
-        T,A,kfs,krevs,efficiencyinds,Gs,rxnarray,mu,jacobian,sensitivity,false,MVector(false),MVector(0.0),stationary), y0, p
+        T,A,kfs,krevs,efficiencyinds,Gs,rxnarray,mu,jacobian,sensitivity,false,MVector(false),MVector(0.0),p), y0, p
 end
 export ConstantTADomain
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -37,6 +37,7 @@ export AbstractVariableKDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
     p::Array{W,1}
+    thermovariabledict::Dict{String,Int64}
 end
 function ConstantTPDomain(;phase::E2,initialconds::Dict{X,X2},constantspecies::Array{X3,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {E<:Real,E2<:AbstractPhase,Q<:AbstractInterface,W<:Real,X,X2,X3}
@@ -97,7 +98,7 @@ function ConstantTPDomain(;phase::E2,initialconds::Dict{X,X2},constantspecies::A
     end
     rxnarray = getreactionindices(phase)
     return ConstantTPDomain(phase,[phase.species[1].index,phase.species[end].index,phase.species[end].index+1],[1,length(phase.species)+length(phase.reactions)],constspcinds,
-        T,P,kfs,krevs,efficiencyinds,Gs,rxnarray,mu,diffs,jacobian,sensitivity,false,MVector(false),MVector(0.0),p), y0, p
+        T,P,kfs,krevs,efficiencyinds,Gs,rxnarray,mu,diffs,jacobian,sensitivity,false,MVector(false),MVector(0.0),p, Dict("V"=>phase.species[end].index+1)), y0, p
 end
 export ConstantTPDomain
 
@@ -114,6 +115,7 @@ export ConstantTPDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
     p::Array{W,1}
+    thermovariabledict::Dict{String,Int64}
 end
 function ConstantVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {E,X,X2,Z<:IdealGas,Q<:AbstractInterface}
@@ -164,7 +166,7 @@ function ConstantVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arra
     end
     rxnarray = getreactionindices(phase)
     return ConstantVDomain(phase,[phase.species[1].index,phase.species[end].index,phase.species[end].index+1,phase.species[end].index+2],[1,length(phase.species)+length(phase.reactions)],constspcinds,
-    V,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    V,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p,Dict("T"=>phase.species[end].index+1,"P"=>phase.species[end].index+2)), y0, p
 end
 export ConstantVDomain
 
@@ -181,6 +183,7 @@ export ConstantVDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
     p::Array{W,1}
+    thermovariabledict::Dict{String,Int64}
 end
 function ConstantPDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {E,X,X2,Z<:IdealGas,Q<:AbstractInterface}
@@ -231,7 +234,7 @@ function ConstantPDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arra
     end
     rxnarray = getreactionindices(phase)
     return ConstantPDomain(phase,[phase.species[1].index,phase.species[end].index,phase.species[end].index+1,phase.species[end].index+2],[1,length(phase.species)+length(phase.reactions)],constspcinds,
-    P,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    P,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p,Dict("T"=>phase.species[end].index+1,"V"=>phase.species[end].index+2)), y0, p
 end
 export ConstantPDomain
 
@@ -249,6 +252,7 @@ export ConstantPDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
     p::Array{W,1}
+    thermovariabledict::Dict{String,Int64}
 end
 function ParametrizedTPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {X,X2,Z<:IdealGas,Q<:AbstractInterface}
@@ -311,7 +315,7 @@ function ParametrizedTPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecie
     end
     rxnarray = getreactionindices(phase)
     return ParametrizedTPDomain(phase,[phase.species[1].index,phase.species[end].index,phase.species[end].index+1],[1,length(phase.species)+length(phase.reactions)],constspcinds,
-    Tfcn,Pfcn,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    Tfcn,Pfcn,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p,Dict("V"=>phase.species[end].index+1)), y0, p
 end
 export ParametrizedTPDomain
 
@@ -328,6 +332,7 @@ export ParametrizedTPDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
     p::Array{W,1}
+    thermovariabledict::Dict{String,Int64}
 end
 function ParametrizedVDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {X,X2,E<:Real,Z<:IdealGas,Q<:AbstractInterface}
@@ -387,7 +392,7 @@ function ParametrizedVDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies
     end
     rxnarray = getreactionindices(phase)
     return ParametrizedVDomain(phase,[phase.species[1].index,phase.species[end].index,phase.species[end].index+1,phase.species[end].index+2],[1,length(phase.species)+length(phase.reactions)],constspcinds,
-    Vfcn,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    Vfcn,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p,Dict("T"=>phase.species[end].index+1,"P"=>phase.species[end].index+2)), y0, p
 end
 export ParametrizedVDomain
 
@@ -404,6 +409,7 @@ export ParametrizedVDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
     p::Array{W,1}
+    thermovariabledict::Dict{String,Int64}
 end
 function ParametrizedPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {X,X2,E<:Real,Z<:IdealGas,Q<:AbstractInterface}
@@ -463,7 +469,7 @@ function ParametrizedPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies
     end
     rxnarray = getreactionindices(phase)
     return ParametrizedPDomain(phase,[phase.species[1].index,phase.species[end].index,phase.species[end].index+1,phase.species[end].index+2],[1,length(phase.species)+length(phase.reactions)],constspcinds,
-    Pfcn,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    Pfcn,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p,Dict("T"=>phase.species[end].index+1,"V"=>phase.species[end].index+2)), y0, p
 end
 export ParametrizedPDomain
 
@@ -488,6 +494,7 @@ export ParametrizedPDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
     p::Array{W,1}
+    thermovariabledict::Dict{String,Int64}
 end
 function ConstantTVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse=false,sensitivity=false) where {E,X,X2, Z<:AbstractPhase,Q<:AbstractInterface,W<:Real}
@@ -545,7 +552,7 @@ function ConstantTVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arr
     end
     rxnarray = getreactionindices(phase)
     return ConstantTVDomain(phase,[phase.species[1].index,phase.species[end].index],[1,length(phase.species)+length(phase.reactions)],constspcinds,
-        T,V,kfs,krevs,kfsnondiff,efficiencyinds,Gs,rxnarray,mu,diffs,jacobian,sensitivity,false,MVector(false),MVector(0.0),p), y0, p
+        T,V,kfs,krevs,kfsnondiff,efficiencyinds,Gs,rxnarray,mu,diffs,jacobian,sensitivity,false,MVector(false),MVector(0.0),p,Dict{String,Int64}()), y0, p
 end
 export ConstantTVDomain
 
@@ -563,6 +570,7 @@ export ConstantTVDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
     p::Array{W,1}
+    thermovariabledict::Dict{String,Int64}
 end
 function ParametrizedTConstantVDomain(;phase::IdealDiluteSolution,initialconds::Dict{X,X3},constantspecies::Array{X2,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false) where {X,X2,X3,Q<:AbstractInterface}
@@ -614,7 +622,7 @@ function ParametrizedTConstantVDomain(;phase::IdealDiluteSolution,initialconds::
     end
     rxnarray = getreactionindices(phase)
     return ParametrizedTConstantVDomain(phase,[phase.species[1].index,phase.species[end].index],[1,length(phase.species)+length(phase.reactions)],constspcinds,
-    Tfcn,V,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p), y0, p
+    Tfcn,V,efficiencyinds,rxnarray,jacobian,sensitivity,MVector(false),MVector(0.0),p,Dict{String,Int64}()), y0, p
 end
 export ParametrizedTConstantVDomain
 
@@ -638,6 +646,7 @@ export ParametrizedTConstantVDomain
     jacuptodate::MArray{Tuple{1},Bool,1,1}=MVector(false)
     t::MArray{Tuple{1},W2,1,1}=MVector(0.0)
     p::Array{W,1}
+    thermovariabledict::Dict{String,Int64}
 end
 function ConstantTADomain(;phase::E2,initialconds::Dict{X,X2},constantspecies::Array{X3,1}=Array{String,1}(),
     sparse::Bool=false,sensitivity::Bool=false,stationary::Bool=false) where {E<:Real,E2<:AbstractPhase,W<:Real,X,X2,X3}
@@ -686,7 +695,7 @@ function ConstantTADomain(;phase::E2,initialconds::Dict{X,X2},constantspecies::A
     end
     rxnarray = getreactionindices(phase)
     return ConstantTADomain(phase,[phase.species[1].index,phase.species[end].index],[1,length(phase.species)+length(phase.reactions)],constspcinds,
-        T,A,kfs,krevs,efficiencyinds,Gs,rxnarray,mu,jacobian,sensitivity,false,MVector(false),MVector(0.0),p), y0, p
+        T,A,kfs,krevs,efficiencyinds,Gs,rxnarray,mu,jacobian,sensitivity,false,MVector(false),MVector(0.0),p,Dict{String,Int64}()), y0, p
 end
 export ConstantTADomain
 

--- a/src/PhaseState.jl
+++ b/src/PhaseState.jl
@@ -192,7 +192,7 @@ export getkfkrev
     return kfs,krev
 end
 
-@inline function getkfkrevs(phase::U,T::W1,P::W2,C::W3,N::W4,ns::Q1,Gs::Q2,diffs::Q3,V::W5;kfs::W6=nothing) where {U<:AbstractPhase,W6,W5<:Real,W1<:Real,W2<:Real,W3<:Real,W4<:Real, Q1<:AbstractArray,Q2<:Union{ReverseDiff.TrackedArray,Tracker.TrackedArray},Q3<:AbstractArray} #autodiff p
+@inline function getkfkrevs(phase::U,T::W1,P::W2,C::W3,N::W4,ns::Q1,Gs::Q2,diffs::Q3,V::W5;kfs::W6=nothing) where {U<:AbstractPhase,W6,W5<:Real,W1<:Real,W2<:Real,W3<:Real,W4<:Real, Q1<:AbstractArray,Q2,Q3<:AbstractArray} #autodiff p
     if !phase.diffusionlimited && kfs === nothing
         kfs = getkfs(phase,T,P,C,ns,V)
         krev = @fastmath kfs./getKcs(phase,T,Gs)

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -148,7 +148,41 @@ function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=In
         end
     else
         ind = findfirst(isequal(target),bsol.names)
+        sensdomain,sensspcnames,senstooriginspcind,senstooriginrxnind = getsensdomain(bsol.domain,ind)
+        if :thermovariabledict in fieldnames(typeof(bsol.domain))
+            yinds = vcat(senstooriginspcind,collect(values(bsol.domain.thermovariabledict)))
+        else
+            yinds = vcat(senstooriginspcind)
+        end
+        pinds = vcat(senstooriginspcind,length(bsol.domain.phase.species).+senstooriginrxnind)
+        ind = findfirst(isequal(target),sensspcnames)
     end
+    
+    function sensg(y::X,p::Array{Y,1},t::Z) where {Q,V,X,Y<:Float64,Z}
+        sensy = y[yinds]
+        sensp = p[pinds]
+        dy = similar(sensy,length(sensy))
+        return dydtreactor!(dy,sensy,t,sensdomain,[],p=sensp)[ind]
+    end
+    function sensg(y::Array{X,1},p::Y,t::Z) where {Q,V,X<:Float64,Y,Z} 
+        sensy = y[yinds]
+        sensp = p[pinds]
+        dy = similar(sensp,length(sensy))
+        return dydtreactor!(dy,sensy,t,sensdomain,[],p=sensp)[ind]
+    end
+    function sensg(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:Float64,Y<:Float64,Z} 
+        sensy = y[yinds]
+        sensp = p[pinds]
+        dy = similar(sensy,length(sensy))
+        return dydtreactor!(dy,sensy,t,sensdomain,[],p=sensp)[ind]
+    end
+    function sensg(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:ForwardDiff.Dual,Y<:ForwardDiff.Dual,Z} 
+        sensy = y[yinds]
+        sensp = p[pinds]
+        dy = similar(sensy,length(sensy))
+        return dydtreactor!(dy,sensy,t,sensdomain,[],p=sensp)[ind]
+    end
+    
     function g(y::X,p::Array{Y,1},t::Z) where {Q,V,X,Y<:Float64,Z} 
         dy = similar(y,length(y))
         return dydtreactor!(dy,y,t,bsol.domain,[],p=p)[ind]
@@ -165,12 +199,33 @@ function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=In
         dy = similar(y,length(y))
         return dydtreactor!(dy,y,t,bsol.domain,[],p=p)[ind]
     end
+
+    dsensgdu(out, y, p, t) = ForwardDiff.gradient!(out, y -> sensg(y, p, t), y)
+    dsensgdp(out, y, p, t) = ForwardDiff.gradient!(out, p -> sensg(y, p, t), p)
     dgdu(out, y, p, t) = ForwardDiff.gradient!(out, y -> g(y, p, t), y)
     dgdp(out, y, p, t) = ForwardDiff.gradient!(out, p -> g(y, p, t), p)
-    du0,dpadj = adjoint_sensitivities(bsol.sol,solver,g,nothing,(dgdu,dgdp);sensealg=sensalg,abstol=abstol,reltol=reltol,kwargs...)
+    dsensgdurevdiff(out, y, p, t) = ReverseDiff.gradient!(out, y -> sensg(y, p, t), y)
+    dsensgdprevdiff(out, y, p, t) = ReverseDiff.gradient!(out, p -> sensg(y, p, t), p)
+    dgdurevdiff(out, y, p, t) = ReverseDiff.gradient!(out, y -> g(y, p, t), y)
+    dgdprevdiff(out, y, p, t) = ReverseDiff.gradient!(out, p -> g(y, p, t), p)
+    
+    pethane = 160
+    if length(bsol.domain.p)<= pethane
+        if target in ["T","V","P"]
+            du0,dpadj = adjoint_sensitivities(bsol.sol,solver,g,nothing,(dgdu,dgdp);sensealg=sensalg,abstol=abstol,reltol=reltol,kwargs...)
+        else
+            du0,dpadj = adjoint_sensitivities(bsol.sol,solver,sensg,nothing,(dsensgdu,dsensgdp);sensealg=sensalg,abstol=abstol,reltol=reltol,kwargs...)
+        end
+    else
+        if target in ["T","V","P"]
+            du0,dpadj = adjoint_sensitivities(bsol.sol,solver,g,nothing,(dgdurevdiff,dgdprevdiff);sensealg=sensalg,abstol=abstol,reltol=reltol,kwargs...)
+        else
+            du0,dpadj = adjoint_sensitivities(bsol.sol,solver,sensg,nothing,(dsensgdurevdiff,dsensgdprevdiff);sensealg=sensalg,abstol=abstol,reltol=reltol,kwargs...)
+        end
+    end
     dpadj[length(bsol.domain.phase.species)+1:end] .*= bsol.domain.p[length(bsol.domain.phase.species)+1:end]
     if !(target in ["T","V","P"])
-        dpadj ./= bsol.sol(bsol.sol.t[end])[ind]
+        dpadj ./= bsol.sol(bsol.sol.t[end])[senstooriginspcind[ind]]
     end
     return dpadj
 end

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -141,7 +141,11 @@ based alternative algorithm is slower, but avoids this concern.
 function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(false)),abstol::Float64=1e-6,reltol::Float64=1e-3,kwargs...) where {Q,W,W2}
     @assert target in bsol.names || target in ["T","V","P"]
     if target in ["T","V","P"]
-        ind = getthermovariableindex(bsol.domain,target)
+        if haskey(bsol.domain.thermovariabledict, target)
+            ind = bsol.domain.thermovariabledict[target]
+        else
+            throw(error("$(bsol.domain) doesn't have $target in its thermovariables"))
+        end
     else
         ind = findfirst(isequal(target),bsol.names)
     end

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -48,3 +48,38 @@ function getspline(xs,vals;s=1e-10)
     F(x::T) where {T} = _predict(smspl,x)
     return F
 end
+
+# obtained from SmoothingSpline.jl and modified the input typing for ReverseDiff TrackedReal
+function _predict(spl::SmoothingSpline{T}, x::T1) where {T<:Union{Float32, Float64},T1}
+    n = length(spl.Xdesign)
+    idxl = searchsortedlast(spl.Xdesign, x)
+    idxr = idxl + 1
+    if idxl == 0 # linear extrapolation to the left
+        gl = spl.g[1]
+        gr = spl.g[2]
+        γ  = spl.γ[1]
+        xl = spl.Xdesign[1]
+        xr = spl.Xdesign[2]
+        gprime = (gr-gl)/(xr-xl) - 1/6*(xr-xl)*γ
+        val = gl - (xl-x)*gprime
+    elseif idxl == n # linear extrapolation to the right
+        gl = spl.g[n-1]
+        gr = spl.g[n]
+        γ  = spl.γ[n-2]
+        xl = spl.Xdesign[n-1]
+        xr = spl.Xdesign[n]
+        gprime = (gr-gl)/(xr-xl) +1/6*(xr-xl)*γ
+        val = gr + (x - xr)*gprime
+    else # cubic interpolation
+        xl = spl.Xdesign[idxl]
+        xr = spl.Xdesign[idxr]
+        γl = idxl == 1 ? zero(T) : spl.γ[idxl-1]
+        γr = idxl == n-1 ? zero(T) : spl.γ[idxr-1]
+        gl = spl.g[idxl]
+        gr = spl.g[idxr]
+        h = xr-xl
+        val = ((x-xl)*gr + (xr-x)*gl)/h
+        val -=  1/6*(x-xl)*(xr-x)*((1 + (x-xl)/h)*γr + (1+ (xr-x)/h)*γl)
+    end
+    val
+end

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -1,3 +1,5 @@
+using SmoothingSplines
+
 function includeall(dir)
     for (root,dirs,files) in walkdir(dir)
         for file in files
@@ -37,3 +39,12 @@ export evalpoly
     return (length(x),-1)
 end
 export getBoundingIndsSorted
+
+"""
+fit a cubic spline to data and return a function evaluating that spline
+"""
+function getspline(xs,vals;s=1e-10)
+    smspl = fit(SmoothingSpline,xs,vals,s)
+    F(x::T) where {T} = _predict(smspl,x)
+    return F
+end


### PR DESCRIPTION
This PR aims to speed up adjoint sensitivities by constructing a domain that only contains the necessary species and reactions for the target species. In addition, if the size of parameter is larger than a threshold, it switches to ReverseDiff to compute dgdu and dgdp. This should address part of issues mentioned in #51. 
![image](https://user-images.githubusercontent.com/45482070/93691314-7bb77f00-fab1-11ea-9264-e07a53552657.png)
