### PR TITLE
Type stability for function in struct

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -238,13 +238,13 @@ function ConstantPDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arra
 end
 export ConstantPDomain
 
-struct ParametrizedTPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray} <: AbstractVariableKDomain
+struct ParametrizedTPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray,FT<:Function,FP<:Function} <: AbstractVariableKDomain
     phase::N
     indexes::Q #assumed to be in ascending order
     parameterindexes::Q
     constantspeciesinds::Array{S,1}
-    T::Function
-    P::Function
+    T::FT
+    P::FP
     efficiencyinds::Array{I,1}
     rxnarray::Array{Int64,2}
     jacobian::Array{W,2}
@@ -319,12 +319,12 @@ function ParametrizedTPDomain(;phase::Z,initialconds::Dict{X,Any},constantspecie
 end
 export ParametrizedTPDomain
 
-struct ParametrizedVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray} <: AbstractVariableKDomain
+struct ParametrizedVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray,FV<:Function} <: AbstractVariableKDomain
     phase::N
     indexes::Q #assumed to be in ascending order
     parameterindexes::Q
     constantspeciesinds::Array{S,1}
-    V::Function
+    V::FV
     efficiencyinds::Array{I,1}
     rxnarray::Array{Int64,2}
     jacobian::Array{W,2}
@@ -396,12 +396,12 @@ function ParametrizedVDomain(;phase::Z,initialconds::Dict{X,Any},constantspecies
 end
 export ParametrizedVDomain
 
-struct ParametrizedPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray} <: AbstractVariableKDomain
+struct ParametrizedPDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray,FP<:Function} <: AbstractVariableKDomain
     phase::N
     indexes::Q #assumed to be in ascending order
     parameterindexes::Q
     constantspeciesinds::Array{S,1}
-    P::Function
+    P::FP
     efficiencyinds::Array{I,1}
     rxnarray::Array{Int64,2}
     jacobian::Array{W,2}
@@ -556,12 +556,12 @@ function ConstantTVDomain(;phase::Z,initialconds::Dict{X,E},constantspecies::Arr
 end
 export ConstantTVDomain
 
-struct ParametrizedTConstantVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray} <: AbstractVariableKDomain
+struct ParametrizedTConstantVDomain{N<:AbstractPhase,S<:Integer,W<:Real,W2<:Real,I<:Integer,Q<:AbstractArray,FT<:Function} <: AbstractVariableKDomain
     phase::N
     indexes::Q #assumed to be in ascending order
     parameterindexes::Q
     constantspeciesinds::Array{S,1}
-    T::Function
+    T::FT
     V::W
     efficiencyinds::Array{I,1}
     rxnarray::Array{Int64,2}

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -227,16 +227,16 @@ function stickingcoefficient2arrhenius(sc,sitedensity,N,mw;Tmin=300.0,Tmax=2000.
     return Arrhenius(;A=p[1],n=p[2],Ea=p[3])
 end
 
-struct Inlet{Q<:Real,S,V<:AbstractArray,U<:Real,X<:Real} <: AbstractBoundaryInterface
+struct Inlet{Q<:Real,S,V<:AbstractArray,U<:Real,X<:Real,FF<:Function} <: AbstractBoundaryInterface
     domain::S
     y::V
-    F::Function
+    F::FF
     T::U
     P::X
     H::Q
 end
 
-function Inlet(domain::V,conddict::Dict{String,X},F::Function) where {V,X<:Real,B<:Real}
+function Inlet(domain::V,conddict::Dict{String,X},F::FF) where {V,X<:Real,B<:Real,FF<:Function}
     y = makespcsvector(domain.phase,conddict)
     T = conddict["T"]
     P = conddict["P"]
@@ -247,8 +247,8 @@ end
 
 export Inlet
 
-struct Outlet{V} <: AbstractBoundaryInterface
+struct Outlet{V,FF<:Function} <: AbstractBoundaryInterface
     domain::V
-    F::Function
+    F::FF
 end
 export Outlet


### PR DESCRIPTION
Recently I learned that 

```
struct B{T<:Function}
    func::T
end
```

is type stable because it parametrizes the struct by the type of the input function, while

```
struct B
    func::Function
end
```

isn't type stable. I made changes for all the structs that were defined in the latter way.