### PR TITLE
Multidomain and Interfaces Adjoint Sensitivity Analysis 

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -1630,7 +1630,7 @@ end
             @simd for i in domain.indexes[1]:domain.indexes[2]
                 @inbounds @fastmath jac[i,i] -= flow/N
             end
-            @views @inbounds @fastmath jac[domain.indexes[1]:domain.indexes[2],domain.indexes[3]] .-= flow.*ns.*(-C)
+            @views @inbounds @fastmath jac[domain.indexes[1]:domain.indexes[2],domain.indexes[3]] .-= -flow.*ns/(N*V)
         end
     end
 end

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -113,7 +113,7 @@ function evaluate(ri::ReactiveInternalInterfaceConstantTPhi,dydt,domains,T1,T2,p
 end
 
 function evaluate(ri::ReactiveInternalInterfaceConstantTPhi,dydt,domains,T1,T2,phi1,phi2,Gs1,Gs2,cstot,p)
-    if all(p[ri.parameterindexes[1]:ri.parameterindexes[2]] .== ri.kfs)
+    if p[ri.parameterindexes[1]:ri.parameterindexes[2]] == ri.kfs
         kfs = ri.kfs
     else 
         kfs = p[ri.parameterindexes[1]:ri.parameterindexes[2]]

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -69,6 +69,12 @@ function Reactor(domains::T,y0s::W,tspan::W2,interfaces::Z=Tuple(),ps::X=DiffEqB
                 domain.rxnarray[i,j] += k-1
             end
         end
+        for i in 1:length(domain.constantspeciesinds)
+            domain.constantspeciesinds[i] += k-1
+        end
+        for (thermovar,ind) in domain.thermovariabledict
+            domain.thermovariabledict[thermovar] += k-1
+        end
         domain.indexes[1] = k
         k += Nspcs
         domain.indexes[2] = k-1

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -241,7 +241,7 @@ export getrates
 end
 
 @inline function addreactionratecontributions!(dydt::Q,rarray::Array{W2,2},cs::W,kfs::Z,krevs::Y,V) where {Q,Z,Y,T,W,W2}
-    @inbounds for i = 1:size(rarray)[2]
+    @inbounds @simd for i = 1:size(rarray)[2]
         if @inbounds rarray[2,i] == 0
             @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]
         elseif @inbounds rarray[3,i] == 0

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -326,7 +326,8 @@ export addreactionratecontributionsforwardreverse!
     return dydt
 end
 @inline function dydtreactor!(dydt::RC,y::U,t::Z,domains::Q,interfaces::B;p::RV=DiffEqBase.NullParameters(),sensitivity::Bool=true) where {RC,RV,B,Z,U,Q<:Tuple}    
-    cstot = zeros(typeof(y).parameters[1],length(y))
+    cstot = similar(y)
+    cstot .= 0.0
     dydt .= 0.0
     domain = domains[1]
     ns,cs,T,P,V,C,N,mu,kfs,krevs,Hs,Us,Gs,diffs,Cvave,cpdivR,phi = calcthermo(domain,y,t,p)

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -455,7 +455,11 @@ end
 function getadjointsensitivities(syssim::Q,bsol::W3,target::String,solver::W;sensalg::W2=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(false)),abstol::Float64=1e-6,reltol::Float64=1e-3,kwargs...) where {Q,W,W2,W3}
     @assert target in bsol.names || target in ["T","V","P"]
     if target in ["T","V","P"]
-        ind = bsol.domain.indexes[end]
+        if haskey(bsol.domain.thermovariabledict, target)
+            ind = bsol.domain.thermovariabledict[target]
+        else
+            throw(error("$(bsol.domain) doesn't have $target in its thermovariables"))
+        end
     else
         ind = findfirst(isequal(target),bsol.names)+bsol.domain.indexes[1]-1
     end

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -399,19 +399,19 @@ function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=In
     
     function g(y::X,p::Array{Y,1},t::Z) where {Q,V,X,Y<:Float64,Z} 
         dy = similar(y,length(y))
-        return dydtreactor!(dy,y,t,bsol.domain,[],p=p)[ind]
+        return dydtreactor!(dy,y,t,bsol.domain,bsol.interfaces,p=p)[ind]
     end
     function g(y::Array{X,1},p::Y,t::Z) where {Q,V,X<:Float64,Y,Z} 
         dy = similar(p,length(y))
-        return dydtreactor!(dy,y,t,bsol.domain,[],p=p)[ind]
+        return dydtreactor!(dy,y,t,bsol.domain,bsol.interfaces,p=p)[ind]
     end
     function g(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:Float64,Y<:Float64,Z} 
         dy = zeros(length(y))
-        return dydtreactor!(dy,y,t,bsol.domain,[],p=p)[ind]
+        return dydtreactor!(dy,y,t,bsol.domain,bsol.interfaces,p=p)[ind]
     end
     function g(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:ForwardDiff.Dual,Y<:ForwardDiff.Dual,Z} 
         dy = similar(y,length(y))
-        return dydtreactor!(dy,y,t,bsol.domain,[],p=p)[ind]
+        return dydtreactor!(dy,y,t,bsol.domain,bsol.interfaces,p=p)[ind]
     end
 
     dsensgdu(out, y, p, t) = ForwardDiff.gradient!(out, y -> sensg(y, p, t), y)

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -462,19 +462,19 @@ function getadjointsensitivities(syssim::Q,bsol::W3,target::String,solver::W;sen
     domains = Tuple([x.domain for x in syssim.sims])
     function g(y::X,p::Array{Y,1},t::Z) where {Q,V,X,Y<:Float64,Z} 
         dy = similar(y,length(y))
-        return dydtreactor!(dy,y,t,domains,[],p=p)[ind]
+        return dydtreactor!(dy,y,t,domains,syssim.interfaces,p=p)[ind]
     end
     function g(y::Array{X,1},p::Y,t::Z) where {Q,V,X<:Float64,Y,Z} 
         dy = similar(p,length(y))
-        return dydtreactor!(dy,y,t,domains,[],p=p)[ind]
+        return dydtreactor!(dy,y,t,domains,syssim.interfaces,p=p)[ind]
     end
     function g(y::Array{Float64,1},p::Array{Float64,1},t::Z) where {Q,V,Z} 
         dy = similar(p,length(y))
-        return dydtreactor!(dy,y,t,domains,[],p=p)[ind]
+        return dydtreactor!(dy,y,t,domains,syssim.interfaces,p=p)[ind]
     end
     function g(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:ForwardDiff.Dual,Y<:ForwardDiff.Dual,Z} 
         dy = similar(y,length(y))
-        return dydtreactor!(dy,y,t,domains,[],p=p)[ind]
+        return dydtreactor!(dy,y,t,domains,syssim.interfaces,p=p)[ind]
     end
     dgdu(out, y, p, t) = ForwardDiff.gradient!(out, y -> g(y, p, t), y)
     dgdp(out, y, p, t) = ForwardDiff.gradient!(out, p -> g(y, p, t), p)

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -365,9 +365,7 @@ function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=In
         end
     else
         ind = findfirst(isequal(target),bsol.names)
-        if !isempty(bsol.interfaces)
-            nothing
-        else
+        if isempty(bsol.interfaces)
             sensdomain,sensspcnames,senstooriginspcind,senstooriginrxnind = getsensdomain(bsol.domain,ind)
             if :thermovariabledict in fieldnames(typeof(bsol.domain))
                 yinds = vcat(senstooriginspcind,collect(values(bsol.domain.thermovariabledict)))

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -452,7 +452,7 @@ function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=In
     return dpadj
 end
 
-function getadjointsensitivities(syssim::Q,bsol::W3,target::String,solver::W;sensalg::W2=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)),abstol::Float64=1e-6,reltol::Float64=1e-3,kwargs...) where {Q,W,W2,W3}
+function getadjointsensitivities(syssim::Q,bsol::W3,target::String,solver::W;sensalg::W2=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(false)),abstol::Float64=1e-6,reltol::Float64=1e-3,kwargs...) where {Q,W,W2,W3}
     @assert target in bsol.names || target in ["T","V","P"]
     if target in ["T","V","P"]
         ind = bsol.domain.indexes[end]

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -326,7 +326,7 @@ end;
     
     react,y0,p = Reactor((domainV1,domainV2),(y0V1,y0V2),(0.0,0.037),[],(pV1,pV2));
     sol = solve(react.ode,CVODE_BDF(),abstol=1e-16,reltol=1e-6);
-    sysim = SystemSimulation(sol,(domainV1,domainV2),p);
+    sysim = SystemSimulation(sol,(domainV1,domainV2),[],p);
     
     t = 0.03
     @test sol(t)[1:length(spcs)] ≈ solV(t)[1:end-2] rtol=1e-5

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -266,6 +266,37 @@ end;
 
 
 
+@testset "Multi-domain ConstantV sensitivity analysis" begin
+    phaseDict = readinput("../src/testing/superminimal.rms")
+    spcs = phaseDict["phase"]["Species"]
+    rxns = phaseDict["phase"]["Reactions"]
+    ig = IdealGas(spcs,rxns,name="phase")
+    
+    initialcondsV = Dict(["T"=>1000.0,"P"=>10.0e5,"H2"=>0.67,"O2"=>0.33]) 
+    domainV,y0V,pV = ConstantVDomain(phase=ig,initialconds=initialcondsV) #Define the domain (encodes how system thermodynamic properties calculated)
+    
+    reactV = Reactor(domainV,y0V,(0.0,0.037);p=pV) #Create the reactor object
+    solV = solve(reactV.ode,CVODE_BDF(),abstol=1e-16,reltol=1e-6); #solve the ode associated with the reactor
+    simV = Simulation(solV,domainV)
+    
+    initialcondsV1 = Dict(["T"=>1000.0,"P"=>10.0e5,"H2"=>0.67,"O2"=>0.33]) 
+    domainV1,y0V1,pV1 = ConstantVDomain(phase=ig,initialconds=initialcondsV1) #Define the domain (encodes how system thermodynamic properties calculated)
+    initialcondsV2 = Dict(["T"=>1000.0,"P"=>10.0e5,"H2"=>0.67,"O2"=>0.33]) 
+    domainV2,y0V2,pV2 = ConstantVDomain(phase=ig,initialconds=initialcondsV2) #Define the domain (encodes how system thermodynamic properties calculated)
+    
+    react,y0,p = Reactor((domainV1,domainV2),(y0V1,y0V2),(0.0,0.037),[],(pV1,pV2));
+    sol = solve(react.ode,CVODE_BDF(),abstol=1e-16,reltol=1e-6);
+    sysim = SystemSimulation(sol,(domainV1,domainV2),p);
+    
+    t = 0.03
+    @test sol(t)[1:length(spcs)] ≈ solV(t)[1:end-2] rtol=1e-5
+    @test sol(t)[length(spcs)+1:end-4] ≈ solV(t)[1:end-2] rtol=1e-5
+    
+    dpsV = getadjointsensitivities(simV,"H2",CVODE_BDF();sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)),abstol=1e-16,reltol=1e-6)
+    dps = getadjointsensitivities(sysim,sysim.sims[1],"H2",CVODE_BDF();sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)),abstol=1e-16,reltol=1e-6)
+    @test dpsV ≈ dps rtol=1e-4
+end;
+
 @testset "Multi-domain ConstantV and ConstantTP simulation" begin
     phaseDict = readinput("../src/testing/superminimal.rms")
     spcs = phaseDict["phase"]["Species"]

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -292,8 +292,8 @@ end;
     @test sol(t)[1:length(spcs)] ≈ solV(t)[1:end-2] rtol=1e-5
     @test sol(t)[length(spcs)+1:end-4] ≈ solV(t)[1:end-2] rtol=1e-5
     
-    dpsV = getadjointsensitivities(simV,"H2",CVODE_BDF();sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)),abstol=1e-16,reltol=1e-6)
-    dps = getadjointsensitivities(sysim,sysim.sims[1],"H2",CVODE_BDF();sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)),abstol=1e-16,reltol=1e-6)
+    dpsV = getadjointsensitivities(simV,"H2",CVODE_BDF();sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(false)),abstol=1e-16,reltol=1e-6)
+    dps = getadjointsensitivities(sysim,sysim.sims[1],"H2",CVODE_BDF();sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(false)),abstol=1e-16,reltol=1e-6)
     @test dpsV ≈ dps rtol=1e-4
 end;
 


### PR DESCRIPTION
I picked up the work @mjohnson541 did on branch `multidomainsens` and make changes to enable adjoint sensitivity analysis on 
1. single domain reactor with interfaces
2. multidomain reactor
3. multidomain reactor with reactive interfaces

Tests are added for 1 and 2. A test run was performed for 3 using the following script. (It takes overnight to run on the server)

```
phaseDict = readinput("../src/testing/ch4o2cat.rms")
gasspcs = phaseDict["gas"]["Species"];
gasrxns = phaseDict["gas"]["Reactions"];
surfacespcs = phaseDict["surface"]["Species"]
surfacerxns = phaseDict["surface"]["Reactions"]
interfacerxns = phaseDict[Set(["gas","surface"])]["Reactions"];

ig = IdealGas(gasspcs,gasrxns;name="gas");
cat = IdealSurface(surfacespcs,surfacerxns,2.486e-5;name="surface");

initialconds = Dict(["T"=>800.0,"P"=>1.0e5,"O2"=>0.2,"N2"=>0.7,"CH4"=>0.1]);
domaingas,y0gas,pgas = ConstantTPDomain(phase=ig,initialconds=initialconds,);

V = 8.314*800.0/1.0e5
A = 1.0e5*V
initialconds = Dict(["T"=>800.0,"A"=>A,"vacantX"=>cat.sitedensity*A]);
domaincat,y0cat,pcat = ConstantTAPhiDomain(phase=cat,initialconds=initialconds,);

inter,pinter = ReactiveInternalInterfaceConstantTPhi(domaingas,domaincat,interfacerxns,800.0,A);

react,y0,p = Reactor((domaingas,domaincat),(y0gas,y0cat),(0.0,0.1),(inter,),(pgas,pcat,pinter));

sol = solve(react.ode,CVODE_BDF(),abstol=1e-20,reltol=1e-6);

ssys = SystemSimulation(sol,(domaingas,domaincat,),(inter,),p);

dps = getadjointsensitivities(ssys,ssys.sims[1],"CH4",CVODE_BDF();sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(false)),abstol=1e-16,reltol=1e-6)
```