### PR TITLE
Fix multidomain AutomaticMechanismAnalysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.dot
 docs/build/
 .DS_Store
+deps/build.log

--- a/src/AutomaticMechanismAnalysis.jl
+++ b/src/AutomaticMechanismAnalysis.jl
@@ -236,6 +236,7 @@ function analyzespc(sim,spcname,t;N=10,tol=1e-3,branchthreshold=0.9,
         )
 
     spcind = findfirst(isequal(spcname),sim.names)
+    @assert spcind != nothing "$spcname not found"
     dSdt = gettransitoryadjoint(sim,t,spcname,spcind,transitorysensitivitymethod)
 
     rop = rops(sim,t)

--- a/src/AutomaticMechanismAnalysis.jl
+++ b/src/AutomaticMechanismAnalysis.jl
@@ -363,8 +363,10 @@ function eliminatereasons(spcind,rxnind,branches,rps,dSdtspc;branchthreshold=0.9
     branchesout = Array{Branching,1}()
     for branch in branches
         ind = findfirst(isequal(rxnind),branch.rxninds)
-        if branch.branchingratios[ind] < branchthreshold
-            push!(branchesout,branch)
+        if ind !== nothing
+            if branch.branchingratios[ind] < branchthreshold
+                push!(branchesout,branch)
+            end
         end
     end
     rpouts = Array{ReactionPath,1}()

--- a/src/AutomaticMechanismAnalysis.jl
+++ b/src/AutomaticMechanismAnalysis.jl
@@ -217,7 +217,7 @@ function gettransitoryadjoint(sim,t,spcname,spcind,transitorysensitivitymethod)
         return transitorysensitivitymethod(sim,t,spcname)
     else
         dSdt = transitorysensitivitymethod(sim,t)
-        return dSdt[spcind,:]
+        return dSdt[spcind+sim.domain.indexes[1]-1,:]
     end
 end
 
@@ -253,7 +253,7 @@ function analyzespc(sim,spcname,t;N=10,tol=1e-3,branchthreshold=0.9,
     end
     rts = rates(sim,t)
 
-    dSdtspc = dSdt[length(sim.names)+1:end]
+    @views dSdtspc = dSdt[length(sim.domain.phase.species)+sim.domain.parameterindexes[1]:sim.domain.parameterindexes[2]]
 
     #find sensitive reactions
     inds = reverse(sortperm(abs.(dSdtspc)))

--- a/src/AutomaticMechanismAnalysis.jl
+++ b/src/AutomaticMechanismAnalysis.jl
@@ -16,14 +16,14 @@ based on production/loss < 1/steptol for forward and
 production/loss > steptol for reverse direction and stops accordingly
 """
 function stepnetwork(sim,statespcind,ropp,ropl,rts;forward=true,i=0,steptol=1e-2)
-    ratio = sum(ropp[:,statespcind])/sum(ropl[:,statespcind])
+    @views ratio = sum(ropp[:,statespcind])/sum(ropl[:,statespcind])
     if forward
         if ratio > 1.0/steptol
             return (0,[0,])
         elseif i == 0
-            rxnind = argmax(ropl[:,statespcind])
+            @views rxnind = argmax(ropl[:,statespcind])
         else
-            rxnind = reverse(sortperm(ropl[:,statespcind]))[i]
+            @views rxnind = reverse(sortperm(ropl[:,statespcind]))[i]
         end
         rt = rts[rxnind]
         if rt > 0.0
@@ -36,9 +36,9 @@ function stepnetwork(sim,statespcind,ropp,ropl,rts;forward=true,i=0,steptol=1e-2
         if ratio < steptol
             return (0,[0,])
         elseif i == 0
-            rxnind = argmax(ropp[:,statespcind])
+            @views rxnind = argmax(ropp[:,statespcind])
         else
-            rxnind = reverse(sortperm(ropp[:,statespcind]))[i]
+            @views rxnind = reverse(sortperm(ropp[:,statespcind]))[i]
         end
         rt = rts[rxnind]
         if rt > 0.0
@@ -187,11 +187,11 @@ function getbranching(sim,rxnind,ropl,rts)
     branches = Array{Branching,1}()
     for (i,spc) in enumerate(spcs)
         ind = findfirst(isequal(spc.name),sim.names)
-        rinds = reverse(sortperm(ropl[:,ind]))
-        rvals = (ropl[:,ind]/sum(ropl[:,ind]))[rinds]
+        @views rinds = reverse(sortperm(ropl[:,ind]))
+        @views rvals = (ropl[:,ind]/sum(ropl[:,ind]))[rinds]
         indend = findfirst(isequal(0.0),rvals)
-        rinds = rinds[1:indend]
-        rvals = rvals[1:indend]
+        @views rinds = rinds[1:indend]
+        @views rvals = rvals[1:indend]
         push!(branches,Branching(ind,rinds,rvals))
     end
     return branches
@@ -313,8 +313,8 @@ than branchtol the other species involved are considered coupled
 """
 function getcoupledspecies(sim,spcind,rxnind,ropp,ropl,rts;branchtol=0.2)
     spcsinds = Array{Int64,1}()
-    totflux = sum(ropl[:,spcind])
-    inds = reverse(sortperm(ropl[:,spcind]))
+    @views totflux = sum(ropl[:,spcind])
+    @views inds = reverse(sortperm(ropl[:,spcind]))
     i = 1
     ind = inds[i]
     for ind in inds

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -46,8 +46,20 @@ struct SystemSimulation{Q,B<:AbstractODESolution,X,Y,Z}
     p::Array{Float64,1}
 end
 
+function getinterfacesfordomain(domain,interfaces)
+    return [inter for inter in interfaces if interofdomain(inter,domain)]
+end
+
+function interofdomain(inter,domain)
+    if hasfield(typeof(inter),:domain)
+        return domain==inter.domain
+    elseif hasfield(typeof(inter),:domain1)
+        return domain==inter.domain1 || domain==inter.domain2
+    end
+end
+
 function SystemSimulation(sol,domains,interfaces,p)
-    sims = Tuple([Simulation(sol,domain) for domain in domains])
+    sims = Tuple([Simulation(sol,domain,getinterfacesfordomain(domain,interfaces),p) for domain in domains])
     names = Array{String,1}()
     reactions = Array{ElementaryReaction,1}()
     species = Array{Species,1}()

--- a/src/TestReactors.jl
+++ b/src/TestReactors.jl
@@ -293,6 +293,25 @@ dSdttrapetrue = [0.0, 0.0, 0.0, -0.0, -0.0, 0.0, -0.0, 0.0, 0.0, 0.0, -0.0, 0.0,
 out = analyzespc(sim,"ethane",0.01)
 s = getrxnanalysisstring(sim,out[1])
 @test s == "Analyzing ethane sensitivity to HO2+ethane<=>H2O2+C2H5 at a value of -0.0379814 \n\nKey branching for HO2 \nHO2+HO2<=>O2+H2O2 had a branching ratio of 0.632358 \nHO2+ethane<=>H2O2+C2H5 had a branching ratio of 0.358444 \n\nKey branching for ethane \nOH+ethane<=>H2O+C2H5 had a branching ratio of 0.576145 \nHO2+ethane<=>H2O2+C2H5 had a branching ratio of 0.328068 \nH+ethane<=>H2+C2H5 had a branching ratio of 0.0313989 \nO2+ethane<=>HO2+C2H5 had a branching ratio of 0.0291454 \nCH3+CH3<=>ethane had a branching ratio of 0.0165147 \nCH3+ethane<=>CH4+C2H5 had a branching ratio of 0.0145334 \n\nAssociated key reaction path in ethane loss direction \nHO2+ethane<=>H2O2+C2H5 at path branching of 0.328068 \nHO2+C2H4<=>O2+C2H5 at path branching of 0.919341 \n\nAssociated key reaction path in ethane loss direction \nHO2+ethane<=>H2O2+C2H5 at path branching of 0.328068 \nHO2+C2H4<=>O2+C2H5 at path branching of 0.919341 \n\nAssociated key reaction path in ethane loss direction \nHO2+ethane<=>H2O2+C2H5 at path branching of 0.328068 \nHO2+C2H4<=>O2+C2H5 at path branching of 0.919341 \n\n\n"
+
+phaseDict = readinput("../src/testing/ethane.rms")
+spcs = phaseDict["phase"]["Species"]
+rxns = phaseDict["phase"]["Reactions"]
+ig1 = IdealGas(spcs,[],name="phase1")
+ig2 = IdealGas(spcs,rxns,name="phase2")
+
+initialcondsV1 = Dict(["T"=>1000.0,"P"=>2.0e5,"ethane"=>1.0,"Ar"=>1.0,"O2"=>3.5])
+domainV1,y0V1,pV1 = ConstantPDomain(phase=ig1,initialconds=initialcondsV1) #Define the domain (encodes how system thermodynamic properties calculated)
+initialcondsV2 = Dict(["T"=>1000.0,"P"=>2.0e5,"ethane"=>1.0,"Ar"=>1.0,"O2"=>3.5])
+domainV2,y0V2,pV2 = ConstantPDomain(phase=ig2,initialconds=initialcondsV2) #Define the domain (encodes how system thermodynamic properties calculated)
+
+react,y0,p = Reactor((domainV1,domainV2),(y0V1,y0V2),(0.0,1.0),[],(pV1,pV2));
+sol = solve(react.ode,CVODE_BDF(),abstol=1e-16,reltol=1e-6);
+sysim = SystemSimulation(sol,(domainV1,domainV2),[],p);
+
+out = analyzespc(sysim.sims[2],"ethane",0.01)
+s = getrxnanalysisstring(sysim.sims[2],out[1])
+@test s == "Analyzing ethane sensitivity to HO2+ethane<=>H2O2+C2H5 at a value of -0.0379814 \n\nKey branching for HO2 \nHO2+HO2<=>O2+H2O2 had a branching ratio of 0.632358 \nHO2+ethane<=>H2O2+C2H5 had a branching ratio of 0.358444 \n\nKey branching for ethane \nOH+ethane<=>H2O+C2H5 had a branching ratio of 0.576145 \nHO2+ethane<=>H2O2+C2H5 had a branching ratio of 0.328068 \nH+ethane<=>H2+C2H5 had a branching ratio of 0.0313989 \nO2+ethane<=>HO2+C2H5 had a branching ratio of 0.0291454 \nCH3+CH3<=>ethane had a branching ratio of 0.0165147 \nCH3+ethane<=>CH4+C2H5 had a branching ratio of 0.0145334 \n\nAssociated key reaction path in ethane loss direction \nHO2+ethane<=>H2O2+C2H5 at path branching of 0.328068 \nHO2+C2H4<=>O2+C2H5 at path branching of 0.919341 \n\nAssociated key reaction path in ethane loss direction \nHO2+ethane<=>H2O2+C2H5 at path branching of 0.328068 \nHO2+C2H4<=>O2+C2H5 at path branching of 0.919341 \n\nAssociated key reaction path in ethane loss direction \nHO2+ethane<=>H2O2+C2H5 at path branching of 0.328068 \nHO2+C2H4<=>O2+C2H5 at path branching of 0.919341 \n\n\n"
 end;
 
 #Parametrized T and P Ideal Gas

--- a/src/TransitorySensitivities.jl
+++ b/src/TransitorySensitivities.jl
@@ -150,7 +150,7 @@ function normalizefulltransitorysensitivities!(dSdt,sim::Simulation,t)
     y = sim.sol(t)
     @views ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
     dSdt .*= sim.domain.p'
-    dSdt[1:sim.domain.indexes[2],:] ./= ns
+    @views dSdt[sim.domain.indexes[1]:sim.domain.indexes[2],:] ./= ns
     return dSdt
 end
 
@@ -168,7 +168,7 @@ function normalizeparamtransitorysensitivities!(dSdt,sim::Simulation,t,ind)
     y = sim.sol(t)
     @views ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
     dSdt .*= sim.domain.p[ind]
-    dSdt[1:length(sim.domain.phase.species)] ./= ns
+    @views dSdt[sim.domain.indexes[1]:sim.domain.indexes[2]] ./= ns
     return dSdt
 end
 

--- a/src/TransitorySensitivities.jl
+++ b/src/TransitorySensitivities.jl
@@ -148,7 +148,7 @@ end
 
 function normalizefulltransitorysensitivities!(dSdt,sim::Simulation,t)
     y = sim.sol(t)
-    ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
+    @views ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
     dSdt .*= sim.domain.p'
     dSdt[1:sim.domain.indexes[2],:] ./= ns
     return dSdt
@@ -158,15 +158,15 @@ function normalizefulltransitorysensitivities!(dSdt,ssys::SystemSimulation,t)
     y = ssys.sol(t)
     dSdt .*= ssys.p'
     for sim in ssys.sims
-        ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
-        dSdt[sim.domain.indexes[1]:sim.domain.indexes[2],:] ./= ns
+        @views ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
+        @views dSdt[sim.domain.indexes[1]:sim.domain.indexes[2],:] ./= ns
     end
     return dSdt
 end
 
 function normalizeparamtransitorysensitivities!(dSdt,sim::Simulation,t,ind)
     y = sim.sol(t)
-    ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
+    @views ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
     dSdt .*= sim.domain.p[ind]
     dSdt[1:length(sim.domain.phase.species)] ./= ns
     return dSdt
@@ -175,9 +175,9 @@ end
 function normalizeparamtransitorysensitivities!(dSdt,ssys::SystemSimulation,t,ind)
     y = ssys.sol(t)
     for sim in ssys.sims
-        ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
+        @views ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
         dSdt .*= ssys.domain.p[ind]
-        dSdt[sim.domain.indexes[1]:sim.domain.indexes[2]] ./= ns
+        @views dSdt[sim.domain.indexes[1]:sim.domain.indexes[2]] ./= ns
     end
     return dSdt
 end
@@ -194,7 +194,7 @@ end
 function normalizeadjointtransitorysensitivities!(dSdt,ssys::SystemSimulation,t,ind)
     y = ssys.sol(t)
     for sim in ssys.sims
-        dSdt[sim.domain.parameterindexes[1]:sim.domain.parameterindexes[2]] .*= ssys.domain.p[sim.domain.parameterindexes[1]:sim.domain.parameterindexes[2]]
+        @views dSdt[sim.domain.parameterindexes[1]:sim.domain.parameterindexes[2]] .*= ssys.domain.p[sim.domain.parameterindexes[1]:sim.domain.parameterindexes[2]]
         if ind >= sim.domain.indexes[1] && ind <= sim.domain.indexes[2]
             dSdt ./= y[ind]
         end

--- a/src/TransitorySensitivities.jl
+++ b/src/TransitorySensitivities.jl
@@ -113,7 +113,7 @@ function getdividingtimescale(Jy;taumax=1e4,taumin=1e-18,taures=10.0^0.5,usediag
 end
 
 function getdividingtimescale(sim,t;taumax=1e6,taumin=1e-18,taures=10.0^0.5,usediag=true)
-    Jy = jacobiany(sim.sol(t),sim.domain.p,t,sim.domain,sim.interfaces);
+    Jy = jacobiany(sim.sol(t),sim.p,t,sim.domain,sim.interfaces);
     getdividingtimescale(Jy,taumax=taumax,taumin=taumin,taures=taures,usediag=usediag)
 end
 export getdividingtimescale
@@ -149,7 +149,7 @@ end
 function normalizefulltransitorysensitivities!(dSdt,sim::Simulation,t)
     y = sim.sol(t)
     @views ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
-    dSdt .*= sim.domain.p'
+    dSdt .*= sim.p'
     @views dSdt[sim.domain.indexes[1]:sim.domain.indexes[2],:] ./= ns
     return dSdt
 end
@@ -167,7 +167,7 @@ end
 function normalizeparamtransitorysensitivities!(dSdt,sim::Simulation,t,ind)
     y = sim.sol(t)
     @views ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
-    dSdt .*= sim.domain.p[ind]
+    dSdt .*= sim.p[ind]
     @views dSdt[sim.domain.indexes[1]:sim.domain.indexes[2]] ./= ns
     return dSdt
 end
@@ -176,7 +176,7 @@ function normalizeparamtransitorysensitivities!(dSdt,ssys::SystemSimulation,t,in
     y = ssys.sol(t)
     for sim in ssys.sims
         @views ns = y[sim.domain.indexes[1]:sim.domain.indexes[2]]
-        dSdt .*= ssys.domain.p[ind]
+        dSdt .*= ssys.p[ind]
         @views dSdt[sim.domain.indexes[1]:sim.domain.indexes[2]] ./= ns
     end
     return dSdt
@@ -184,7 +184,7 @@ end
 
 function normalizeadjointtransitorysensitivities!(dSdt,sim::Simulation,t,ind)
     y = sim.sol(t)
-    dSdt .*= sim.domain.p'
+    dSdt .*= sim.p'
     if ind <= sim.domain.indexes[2]
         dSdt ./= y[ind]
     end


### PR DESCRIPTION
Bigger changes:

1. Append the global p vector (corresponding to multidomain) to each Simulation object in SystemSimulation, instead of the local p vector (corresponding to one domain). Append interfaces as well.
2. Uses the global p vector to calculate dSdt and the corresponding global indexes for species and reactions