### PR TITLE
Parser for Cantera yaml input

### DIFF
--- a/src/Parse.jl
+++ b/src/Parse.jl
@@ -254,7 +254,7 @@ parses a YAML input file into a dictionary containing
 partitions of Species and Reaction objects
 """
 function readinputyml(fname::String)
-    D = YAML.load(open(fname))
+    D = YAML.load_file(fname)
     outdict = Dict()
 
     #Units

--- a/src/Parse.jl
+++ b/src/Parse.jl
@@ -227,8 +227,15 @@ for rms (.rms, .yml, .rmg) it parses it directly
 """
 function readinput(fname::String;spcdict::String="",output::String="chem.rms")
     extension = split(fname,".")[end]
-    if extension in ["rms","yml","rmg"]
+    if extension in ["rms","rmg"]
         return readinputyml(fname)
+    elseif extension in ["yml","yaml"] #can be rms yml or cantera yml
+        try
+            return readinputyml(fname)
+        catch
+            convertcanterayml2rmsyml(fname,output=output)
+            return readinputyml(output)
+        end
     elseif extension in ["inp"]
         if spcdict == ""
             convertchemkin2yml(fname,output=output)

--- a/src/yml.jl
+++ b/src/yml.jl
@@ -1,3 +1,6 @@
+using YAML
+using Unitful
+
 function convertchemkin2yml(chemkinpath;spcdictpath="",output="chem.rms")
     if spcdictpath != ""
         spcs,rxns = chemkin.load_chemkin_file(chemkinpath,dictionary_path=spcdictpath)

--- a/src/yml.jl
+++ b/src/yml.jl
@@ -4,12 +4,12 @@ function convertchemkin2yml(chemkinpath;spcdictpath="",output="chem.rms")
     else
         spcs,rxns = chemkin.load_chemkin_file(chemkinpath)
     end
-    writeyml(spcs,rxns;path=output)
+    D = getmechdictfromchemkin(spcs,rxns)
+    writeyml(D;path=output)
 end
 
-function writeyml(spcs,rxns;path="chem.rms")
-    D = getmechdict(spcs,rxns)
-    yaml.dump(D,stream=pybuiltin("open")(path,"w"))
+function writeyml(D;path="chem.rms")
+    YAML.write_file(path,D)
 end
 
 function getmechdictfromchemkin(spcs,rxns)

--- a/src/yml.jl
+++ b/src/yml.jl
@@ -12,7 +12,7 @@ function writeyml(spcs,rxns;path="chem.rms")
     yaml.dump(D,stream=pybuiltin("open")(path,"w"))
 end
 
-function getmechdict(spcs,rxns)
+function getmechdictfromchemkin(spcs,rxns)
     names = [x.label for x in spcs]
     for (i,name) in enumerate(names)
         if count(names.==name) > 1


### PR DESCRIPTION
This PR adds the parser for Cantera yaml input files. Several Cantera yaml input files stored provided in Cantera's repo are used as test cases, listed below. This parser throws informative error messages when encountering currently unsupported thermo models, equation of states, and kinetics expressions.

```
air.yaml
gri30.yaml
gri30_highT.yaml
h2o2.yaml
methane_pox_on_pt.yaml
nDodecane_Reitz.yaml
```

