### PR TITLE
Enabling modeling 5=5 reactions

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -2686,18 +2686,22 @@ export jacobiany!
                 @fastmath @inbounds fderiv = kfs[rxnind]*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]
             elseif @inbounds rxnarray[4,rxnind] == 0
                 @fastmath @inbounds fderiv = kfs[rxnind]*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]
-            else
+            elseif @inbounds rxnarray[5,rxnind] == 0
                 @fastmath @inbounds fderiv = kfs[rxnind]*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]
+            else
+                @fastmath @inbounds fderiv = kfs[rxnind]*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]*cs[rxnarray[5,rxnind]]
             end
 
-            if @inbounds rxnarray[6,rxnind] == 0
-                @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[5,rxnind]]
-            elseif @inbounds rxnarray[7,rxnind] == 0
-                @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
+            if @inbounds rxnarray[7,rxnind] == 0
+                @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[6,rxnind]]
             elseif @inbounds rxnarray[8,rxnind] == 0
-                @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
+                @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
+            elseif @inbounds rxnarray[9,rxnind] == 0
+                @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]
+            elseif @inbounds rxnarray[10,rxnind] == 0
+                @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]*cs[rxnarray[9,rxnind]]
             else
-                @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]
+                @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]*cs[rxnarray[9,rxnind]]*cs[rxnarray[10,rxnind]]
             end
         else
             if @inbounds rxnarray[2,rxnind] == 0
@@ -2706,18 +2710,22 @@ export jacobiany!
                 @fastmath @inbounds fderiv = cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]
             elseif @inbounds  rxnarray[4,rxnind] == 0
                 @fastmath @inbounds fderiv = cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]
-            else
+            elseif @inbounds  rxnarray[5,rxnind] == 0
                 @fastmath @inbounds fderiv = cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]
+            else
+                @fastmath @inbounds fderiv = cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]*cs[rxnarray[5,rxnind]]
             end
 
-            if @inbounds rxnarray[6,rxnind] == 0
-                @fastmath @inbounds rderiv = krevs[rxnind]/kfs[rxnind]*cs[rxnarray[5,rxnind]]
-            elseif @inbounds rxnarray[7,rxnind] == 0
-                @fastmath @inbounds rderiv = krevs[rxnind]/kfs[rxnind]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
+            if @inbounds rxnarray[7,rxnind] == 0
+                @fastmath @inbounds rderiv = krevs[rxnind]/kfs[rxnind]*cs[rxnarray[6,rxnind]]
             elseif @inbounds rxnarray[8,rxnind] == 0
-                @fastmath @inbounds rderiv = krevs[rxnind]/kfs[rxnind]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
+                @fastmath @inbounds rderiv = krevs[rxnind]/kfs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
+            elseif @inbounds rxnarray[9,rxnind] == 0
+                @fastmath @inbounds rderiv = krevs[rxnind]/kfs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]
+            elseif @inbounds rxnarray[10,rxnind] == 0
+                @fastmath @inbounds rderiv = krevs[rxnind]/kfs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]*cs[rxnarray[9,rxnind]]
             else
-                @fastmath @inbounds rderiv = krevs[rxnind]/kfs[rxnind]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]
+                @fastmath @inbounds rderiv = krevs[rxnind]/kfs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]*cs[rxnarray[9,rxnind]]*cs[rxnarray[10,rxnind]]
             end
         end
 
@@ -2750,33 +2758,57 @@ export jacobiany!
                     @inbounds jacp[rxnarray[3,rxnind],rxnarray[4,rxnind]] -= gderiv
                     @inbounds jacp[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= gderiv
                     @inbounds _spreadreactantpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[4,rxnind])
+                    if @inbounds rxnarray[5, rxnind] !== 0
+                        @inbounds jacp[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[5, rxnind], rxnarray[3, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[5, rxnind], rxnarray[4, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[3, rxnind], rxnarray[5, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[4, rxnind], rxnarray[5, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= gderiv
+                        @inbounds _spreadreactantpartials!(jacp, gderiv, rxnarray, rxnind, rxnarray[5, rxnind])
+                    end
                 end
             end
         end
 
-        @inbounds jacp[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= gderiv
-        @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[5,rxnind])
-        if @inbounds rxnarray[6,rxnind] !== 0
-            @inbounds jacp[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= gderiv
-            @inbounds jacp[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= gderiv
-            @inbounds jacp[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= gderiv
-            @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[6,rxnind])
-            if @inbounds rxnarray[7,rxnind] !== 0
-                @inbounds jacp[rxnarray[7,rxnind],rxnarray[5,rxnind]] -= gderiv
-                @inbounds jacp[rxnarray[7,rxnind],rxnarray[6,rxnind]] -= gderiv
-                @inbounds jacp[rxnarray[5,rxnind],rxnarray[7,rxnind]] -= gderiv
-                @inbounds jacp[rxnarray[6,rxnind],rxnarray[7,rxnind]] -= gderiv
-                @inbounds jacp[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= gderiv
-                @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[7,rxnind])
-                if @inbounds rxnarray[8,rxnind] !== 0
-                    @inbounds jacp[rxnarray[8,rxnind],rxnarray[5,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[8,rxnind],rxnarray[6,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[8,rxnind],rxnarray[7,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[5,rxnind],rxnarray[8,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[6,rxnind],rxnarray[8,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[7,rxnind],rxnarray[8,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[8,rxnind],rxnarray[8,rxnind]] -= gderiv
-                    @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[8,rxnind])
+        @inbounds jacp[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= gderiv
+        @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[6,rxnind])
+        if @inbounds rxnarray[7,rxnind] !== 0
+            @inbounds jacp[rxnarray[7,rxnind],rxnarray[6,rxnind]] -= gderiv
+            @inbounds jacp[rxnarray[6,rxnind],rxnarray[7,rxnind]] -= gderiv
+            @inbounds jacp[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= gderiv
+            @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[7,rxnind])
+            if @inbounds rxnarray[8,rxnind] !== 0
+                @inbounds jacp[rxnarray[8,rxnind],rxnarray[6,rxnind]] -= gderiv
+                @inbounds jacp[rxnarray[8,rxnind],rxnarray[7,rxnind]] -= gderiv
+                @inbounds jacp[rxnarray[6,rxnind],rxnarray[8,rxnind]] -= gderiv
+                @inbounds jacp[rxnarray[7,rxnind],rxnarray[8,rxnind]] -= gderiv
+                @inbounds jacp[rxnarray[8,rxnind],rxnarray[8,rxnind]] -= gderiv
+                @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[8,rxnind])
+                if @inbounds rxnarray[9,rxnind] !== 0
+                    @inbounds jacp[rxnarray[9,rxnind],rxnarray[6,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[9,rxnind],rxnarray[7,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[9,rxnind],rxnarray[8,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[6,rxnind],rxnarray[9,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[7,rxnind],rxnarray[9,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[8,rxnind],rxnarray[9,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[9,rxnind],rxnarray[9,rxnind]] -= gderiv
+                    @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[9,rxnind])
+                    if @inbounds rxnarray[10,rxnind] !== 0
+                        @inbounds jacp[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[10, rxnind], rxnarray[8, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[10, rxnind], rxnarray[9, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[8, rxnind], rxnarray[10, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[9, rxnind], rxnarray[10, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= gderiv
+                        @inbounds _spreadproductpartials!(jacp, gderiv, rxnarray, rxnind, rxnarray[10, rxnind])
+                    end
                 end
             end
         end
@@ -2792,20 +2824,24 @@ end
             @fastmath @inbounds fderiv = kfs[rxnind]*cs[rxnarray[1,rxnind]]
         elseif @inbounds rxnarray[3,rxnind] == 0
             @fastmath @inbounds fderiv = kfs[rxnind]*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]
-        elseif @inbounds rxnarray[4,rxnind] == 0 
+        elseif @inbounds rxnarray[4,rxnind] == 0
             @fastmath @inbounds fderiv = kfs[rxnind]*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]
-        else
+        elseif @inbounds rxnarray[5,rxnind] == 0
             @fastmath @inbounds fderiv = kfs[rxnind]*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]
+        else
+            @fastmath @inbounds fderiv = kfs[rxnind]*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]*cs[rxnarray[5,rxnind]]
         end
 
-        if @inbounds rxnarray[6,rxnind] == 0
-            @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[5,rxnind]]
-        elseif @inbounds rxnarray[7,rxnind] == 0
-            @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
-        elseif @inbounds rxnarray[8,rxnind] == 0 
-            @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
+        if @inbounds rxnarray[7,rxnind] == 0
+            @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[6,rxnind]]
+        elseif @inbounds rxnarray[8,rxnind] == 0
+            @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
+        elseif @inbounds rxnarray[9,rxnind] == 0
+            @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]
+        elseif @inbounds rxnarray[10,rxnind] == 0
+            @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]*cs[rxnarray[9,rxnind]]
         else
-            @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]
+            @fastmath @inbounds rderiv = krevs[rxnind]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]*cs[rxnarray[9,rxnind]]*cs[rxnarray[10,rxnind]]
         end
 
         @fastmath flux = fderiv-rderiv
@@ -2837,33 +2873,57 @@ end
                     @inbounds jacp[rxnarray[3,rxnind],rxnarray[4,rxnind]] -= gderiv
                     @inbounds jacp[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= gderiv
                     @inbounds _spreadreactantpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[4,rxnind])
+                    if @inbounds rxnarray[5, rxnind] !== 0
+                        @inbounds jacp[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[5, rxnind], rxnarray[3, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[5, rxnind], rxnarray[4, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[3, rxnind], rxnarray[5, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[4, rxnind], rxnarray[5, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= gderiv
+                        @inbounds _spreadreactantpartials!(jacp, gderiv, rxnarray, rxnind, rxnarray[5, rxnind])
+                    end
                 end
             end
         end
 
-        @inbounds jacp[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= gderiv
-        @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[5,rxnind])
-        if @inbounds rxnarray[6,rxnind] !== 0
-            @inbounds jacp[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= gderiv
-            @inbounds jacp[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= gderiv
-            @inbounds jacp[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= gderiv
-            @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[6,rxnind])
-            if @inbounds rxnarray[7,rxnind] !== 0
-                @inbounds jacp[rxnarray[7,rxnind],rxnarray[5,rxnind]] -= gderiv
-                @inbounds jacp[rxnarray[7,rxnind],rxnarray[6,rxnind]] -= gderiv
-                @inbounds jacp[rxnarray[5,rxnind],rxnarray[7,rxnind]] -= gderiv
-                @inbounds jacp[rxnarray[6,rxnind],rxnarray[7,rxnind]] -= gderiv
-                @inbounds jacp[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= gderiv
-                @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[7,rxnind])
-                if @inbounds rxnarray[8,rxnind] !== 0
-                    @inbounds jacp[rxnarray[8,rxnind],rxnarray[5,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[8,rxnind],rxnarray[6,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[8,rxnind],rxnarray[7,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[5,rxnind],rxnarray[8,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[6,rxnind],rxnarray[8,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[7,rxnind],rxnarray[8,rxnind]] -= gderiv
-                    @inbounds jacp[rxnarray[8,rxnind],rxnarray[8,rxnind]] -= gderiv
-                    @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[8,rxnind])
+        @inbounds jacp[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= gderiv
+        @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[6,rxnind])
+        if @inbounds rxnarray[7,rxnind] !== 0
+            @inbounds jacp[rxnarray[7,rxnind],rxnarray[6,rxnind]] -= gderiv
+            @inbounds jacp[rxnarray[6,rxnind],rxnarray[7,rxnind]] -= gderiv
+            @inbounds jacp[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= gderiv
+            @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[7,rxnind])
+            if @inbounds rxnarray[8,rxnind] !== 0
+                @inbounds jacp[rxnarray[8,rxnind],rxnarray[6,rxnind]] -= gderiv
+                @inbounds jacp[rxnarray[8,rxnind],rxnarray[7,rxnind]] -= gderiv
+                @inbounds jacp[rxnarray[6,rxnind],rxnarray[8,rxnind]] -= gderiv
+                @inbounds jacp[rxnarray[7,rxnind],rxnarray[8,rxnind]] -= gderiv
+                @inbounds jacp[rxnarray[8,rxnind],rxnarray[8,rxnind]] -= gderiv
+                @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[8,rxnind])
+                if @inbounds rxnarray[9,rxnind] !== 0
+                    @inbounds jacp[rxnarray[9,rxnind],rxnarray[6,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[9,rxnind],rxnarray[7,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[9,rxnind],rxnarray[8,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[6,rxnind],rxnarray[9,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[7,rxnind],rxnarray[9,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[8,rxnind],rxnarray[9,rxnind]] -= gderiv
+                    @inbounds jacp[rxnarray[9,rxnind],rxnarray[9,rxnind]] -= gderiv
+                    @inbounds _spreadproductpartials!(jacp,gderiv,rxnarray,rxnind,rxnarray[9,rxnind])
+                    if @inbounds rxnarray[10, rxnind] !== 0
+                        @inbounds jacp[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[10, rxnind], rxnarray[8, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[10, rxnind], rxnarray[9, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[8, rxnind], rxnarray[10, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[9, rxnind], rxnarray[10, rxnind]] -= gderiv
+                        @inbounds jacp[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= gderiv
+                        @inbounds _spreadproductpartials!(jacp, gderiv, rxnarray, rxnind, rxnarray[10, rxnind])
+                    end
                 end
             end
         end

--- a/src/EdgeAnalysis.jl
+++ b/src/EdgeAnalysis.jl
@@ -227,8 +227,8 @@ function getkeyselectioninds(coreedgedomains,coreedgeinters,domains,inters)
         @inbounds rxnindexedge += length(coreedgedomains[i].phase.reactions)
 
         @inbounds indend = length(domains[i].phase.reactions)
-        @inbounds reactantindices[:,ind:ind+indend-1] = domains[i].rxnarray[1:4,:]
-        @inbounds productindices[:,ind:ind+indend-1] = domains[i].rxnarray[5:8,:]
+        @inbounds reactantindices[:,ind:ind+indend-1] = domains[i].rxnarray[1:5,:]
+        @inbounds productindices[:,ind:ind+indend-1] = domains[i].rxnarray[6:10,:]
         ind += indend
     end
 
@@ -239,8 +239,8 @@ function getkeyselectioninds(coreedgedomains,coreedgeinters,domains,inters)
             @inbounds index += length(coreedgeinters[i].phase.reactions)
 
             @inbounds indend = length(inters[i].reactions)
-            @inbounds reactantindices[:,ind:ind+indend] = inters[i].rxnarray[1:4,:]
-            @inbounds productindices[:,ind:ind+indend] = inters[i].rxnarray[5:8,:]
+            @inbounds reactantindices[:,ind:ind+indend] = inters[i].rxnarray[1:5,:]
+            @inbounds productindices[:,ind:ind+indend] = inters[i].rxnarray[6:10,:]
             ind += indend
         end
     end
@@ -270,8 +270,8 @@ function getkeyselectioninds(coreedgedomain::AbstractDomain,coreedgeinters,domai
         end
     end
 
-    @views @inbounds reactantindices = coreedgedomain.rxnarray[1:4,:]
-    @views @inbounds productindices = coreedgedomain.rxnarray[5:8,:]
+    @views @inbounds reactantindices = coreedgedomain.rxnarray[1:5,:]
+    @views @inbounds productindices = coreedgedomain.rxnarray[6:10,:]
     coretoedgespcmap = Dict([i=>findfirst(isequal(spc),coreedgedomain.phase.species) for (i,spc) in enumerate(domain.phase.species)])
     @simd for j = 3:length(domain.indexes)
         @inbounds coretoedgespcmap[domain.indexes[j]] = coreedgedomain.indexes[j]
@@ -305,7 +305,7 @@ function processfluxes(sim::SystemSimulation,
             if @inbounds any(d.rxnarray[:,i].>length(corespeciesconcentrations))
                 continue
             end
-            for j = 1:4
+            for j = 1:5
                 if @inbounds d.rxnarray[j,i] != 0
                     @inbounds corespeciesconsumptionrates[d.rxnarray[j,i]] += frts[i+index]
                     @inbounds corespeciesproductionrates[d.rxnarray[j,i]] += rrts[i+index]
@@ -313,7 +313,7 @@ function processfluxes(sim::SystemSimulation,
                     break
                 end
             end
-            for j = 5:8
+            for j = 6:10
                 if @inbounds d.rxnarray[j,i] != 0
                     @inbounds corespeciesproductionrates[d.rxnarray[j,i]] += frts[i+index]
                     @inbounds corespeciesconsumptionrates[d.rxnarray[j,i]] += rrts[i+index]
@@ -330,7 +330,7 @@ function processfluxes(sim::SystemSimulation,
                 if @inbounds any(d.rxnarray[:,i].>length(corespeciesconcentrations))
                     continue
                 end
-                for j = 1:4
+                for j = 1:5
                     if @inbounds d.rxnarray[j,i] != 0
                         @inbounds corespeciesconsumptionrates[d.rxnarray[j,i]] += frts[i+index]
                         @inbounds corespeciesproductionrates[d.rxnarray[j,i]] += rrts[i+index]
@@ -338,7 +338,7 @@ function processfluxes(sim::SystemSimulation,
                         break
                     end
                 end
-                for j = 5:8
+                for j = 6:10
                     if @inbounds d.rxnarray[j,i] != 0
                         @inbounds corespeciesproductionrates[d.rxnarray[j,i]] += frts[i+index]
                         @inbounds corespeciesconsumptionrates[d.rxnarray[j,i]] += rrts[i+index]
@@ -378,7 +378,7 @@ function processfluxes(sim::Simulation,corespcsinds,corerxninds,edgespcsinds,edg
         if @inbounds  any(d.rxnarray[:,i].>length(corespeciesconcentrations))
             continue
         end
-        for j = 1:4
+        for j = 1:5
             if @inbounds  d.rxnarray[j,i] != 0
                 @inbounds corespeciesconsumptionrates[d.rxnarray[j,i]] += frts[i]
                 @inbounds corespeciesproductionrates[d.rxnarray[j,i]] += rrts[i]
@@ -386,7 +386,7 @@ function processfluxes(sim::Simulation,corespcsinds,corerxninds,edgespcsinds,edg
                 break
             end
         end
-        for j = 5:8
+        for j = 6:10
             if @inbounds  d.rxnarray[j,i] != 0
                 @inbounds corespeciesproductionrates[d.rxnarray[j,i]] += frts[i]
                 @inbounds corespeciesconsumptionrates[d.rxnarray[j,i]] += rrts[i]
@@ -449,7 +449,7 @@ function calcbranchingnumbers(sim,reactantinds,productinds,corespcsinds,corerxni
             end
         end
     end
-   return branchingnums
+    return branchingnums
 end
 
 export calcbranchingnumbers

--- a/src/Phase.jl
+++ b/src/Phase.jl
@@ -147,7 +147,7 @@ function getstoichmatrix(rxnarray,spcs)
         for (j,ind) in enumerate(rxnarray[:,i])
             if ind == 0
                 continue
-            elseif j > 3
+            elseif j > 5
                 M[i,ind] -= 1.0
                 n += 1.0
             else
@@ -257,7 +257,7 @@ Broadcast.broadcastable(p::T) where {T<:AbstractPhase} = Ref(p)
 export broadcastable
 
 function getreactionindices(spcs,rxns) where {Q<:AbstractPhase}
-    arr = zeros(Int64,(8,length(rxns)))
+    arr = zeros(Int64,(10,length(rxns)))
     names = [spc.name for spc in spcs]
     for (i,rxn) in enumerate(rxns)
         inds = [findfirst(isequal(spc),spcs) for spc in rxn.reactants]
@@ -268,7 +268,7 @@ function getreactionindices(spcs,rxns) where {Q<:AbstractPhase}
         end
         for (j,spc) in enumerate(rxn.products)
             ind = findfirst(isequal(spc),spcs)
-            arr[j+4,i] = ind
+            arr[j+5,i] = ind
             rxn.productinds[j] = ind
         end
         if hasproperty(rxn.kinetics,:efficiencies) && length(rxn.kinetics.nameefficiencies) > 0

--- a/src/PhaseState.jl
+++ b/src/PhaseState.jl
@@ -110,20 +110,24 @@ export getDiffusiveRate
     if Nreact == 1
         @fastmath @inbounds dGrxn -= Gs[rxn.reactantinds[1]]
     elseif Nreact == 2
-        @fastmath @inbounds dGrxn -= Gs[rxn.reactantinds[1]]+Gs[rxn.reactantinds[2]]
+        @fastmath @inbounds dGrxn -= Gs[rxn.reactantinds[1]] + Gs[rxn.reactantinds[2]]
     elseif Nreact == 3
-        @fastmath @inbounds dGrxn -= Gs[rxn.reactantinds[1]]+Gs[rxn.reactantinds[2]]+Gs[rxn.reactantinds[3]]
+        @fastmath @inbounds dGrxn -= Gs[rxn.reactantinds[1]] + Gs[rxn.reactantinds[2]] + Gs[rxn.reactantinds[3]]
     elseif Nreact == 4
-        @fastmath @inbounds dGrxn -= Gs[rxn.reactantinds[1]]+Gs[rxn.reactantinds[2]]+Gs[rxn.reactantinds[3]]+Gs[rxn.reactantinds[4]]
+        @fastmath @inbounds dGrxn -= Gs[rxn.reactantinds[1]] + Gs[rxn.reactantinds[2]] + Gs[rxn.reactantinds[3]] + Gs[rxn.reactantinds[4]]
+    elseif Nreact == 5
+        @fastmath @inbounds dGrxn -= Gs[rxn.reactantinds[1]] + Gs[rxn.reactantinds[2]] + Gs[rxn.reactantinds[3]] + Gs[rxn.reactantinds[4]] + Gs[rxn.reactantinds[5]]
     end
     if Nprod == 1
         @fastmath @inbounds dGrxn += Gs[rxn.productinds[1]]
     elseif Nprod == 2
-        @fastmath @inbounds dGrxn += Gs[rxn.productinds[1]]+Gs[rxn.productinds[2]]
+        @fastmath @inbounds dGrxn += Gs[rxn.productinds[1]] + Gs[rxn.productinds[2]]
     elseif Nprod == 3
-        @fastmath @inbounds dGrxn += Gs[rxn.productinds[1]]+Gs[rxn.productinds[2]]+Gs[rxn.productinds[3]]
+        @fastmath @inbounds dGrxn += Gs[rxn.productinds[1]] + Gs[rxn.productinds[2]] + Gs[rxn.productinds[3]]
     elseif Nprod == 4
-        @fastmath @inbounds dGrxn += Gs[rxn.productinds[1]]+Gs[rxn.productinds[2]]+Gs[rxn.productinds[3]]+Gs[rxn.productinds[4]]
+        @fastmath @inbounds dGrxn += Gs[rxn.productinds[1]] + Gs[rxn.productinds[2]] + Gs[rxn.productinds[3]] + Gs[rxn.productinds[4]]
+    elseif Nprod == 5
+        @fastmath @inbounds dGrxn += Gs[rxn.productinds[1]] + Gs[rxn.productinds[2]] + Gs[rxn.productinds[3]] + Gs[rxn.productinds[4]] + Gs[rxn.productinds[5]]
     end
     return @inbounds @fastmath exp(-(dGrxn+rxn.electronchange*phi)/(R*T))*(getC0(ph,T))^(Nprod-Nreact)
 end

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -26,11 +26,11 @@ function Reactor(domain::T,y0::Array{T1,1},tspan::Tuple,interfaces::Z=[];p::X=Sc
     jacyforwarddiff!(J::Q2,y::T,p::V,t::Q) where {Q2,T,Q,V} = jacobianyforwarddiff!(J,y,p,t,domain,interfaces,nothing)
     jacp!(J::Q2,y::T,p::V,t::Q) where {Q2,T,Q,V} = jacobianp!(J,y,p,t,domain,interfaces,nothing)
     jacpforwarddiff!(J::Q2,y::T,p::V,t::Q) where {Q2,T,Q,V} = jacobianpforwarddiff!(J,y,p,t,domain,interfaces,nothing)
-    
+
     psetupsundials(p::T1, t::T2, u::T3, du::T4, jok::Bool, jcurPtr::T5, gamma::T6) where {T1,T2,T3,T4,T5,T6} = _psetupsundials(p, t, u, du, jok, jcurPtr, gamma, jacy!, W::SparseMatrixCSC{Float64, Int64}, preccache::Base.RefValue{IncompleteLU.ILUFactorization{Float64, Int64}}, tau::Float64)
     precsundials(z::T1, r::T2, p::T3, t::T4, y::T5, fy::T6, gamma::T7, delta::T8, lr::T9) where {T1,T2,T3,T4,T5,T6,T7,T8,T9} = _precsundials(z, r, p, t, y, fy, gamma, delta, lr, preccache)
     precsjulia(W::T1,du::T2,u::T3,p::T4,t::T5,newW::T6,Plprev::T7,Prprev::T8,solverdata::T9) where {T1,T2,T3,T4,T5,T6,T7,T8,T9} =  _precsjulia(W,du,u,p,t,newW,Plprev,Prprev,solverdata,tau)
-    
+
     # determine worst sparsity
     y0length = length(y0)
     J = spzeros(y0length,y0length)
@@ -46,7 +46,7 @@ function Reactor(domain::T,y0::Array{T1,1},tspan::Tuple,interfaces::Z=[];p::X=Sc
     @inbounds @views @. W[idxs] = W[idxs] + 1
     prectmp = ilu(W, τ = tau)
     preccache = Ref(prectmp)
-    
+
     if (forwardsensitivities || !forwarddiff) && domain isa Union{ConstantTPDomain,ConstantVDomain,ConstantPDomain,ParametrizedTPDomain,ParametrizedVDomain,ParametrizedPDomain,ConstantTVDomain,ParametrizedTConstantVDomain,ConstantTAPhiDomain}
         if !forwardsensitivities
             odefcn = ODEFunction(dydt;jac=jacy!,paramjac=jacp!)
@@ -118,7 +118,7 @@ function Reactor(domains::T,y0s::W1,tspan::W2,interfaces::Z=Tuple(),ps::X=SciMLB
             n -= 1
         end
     end
-    
+
     p = Array{Float64,1}()
     phases = []
     phaseinds = Array{Tuple,1}()
@@ -144,7 +144,7 @@ function Reactor(domains::T,y0s::W1,tspan::W2,interfaces::Z=Tuple(),ps::X=SciMLB
                     end
                 end
             end
-        else 
+        else
             domain.parameterindexes[1] = length(p)+1
             domain.parameterindexes[2] = length(p)+length(ps[i])
             push!(phaseinds,(length(p)+1,length(p)+length(ps[i])))
@@ -152,7 +152,7 @@ function Reactor(domains::T,y0s::W1,tspan::W2,interfaces::Z=Tuple(),ps::X=SciMLB
             p = vcat(p,ps[i])
         end
     end
-    
+
     for (i,inter) in enumerate(interfaces)
         if isa(inter, AbstractReactiveInternalInterface)
             ind1 = findfirst(isequal(inter.domain1),domains)
@@ -174,7 +174,7 @@ function Reactor(domains::T,y0s::W1,tspan::W2,interfaces::Z=Tuple(),ps::X=SciMLB
             p = vcat(p,ps[i+length(domains)])
         end
     end
-    
+
     dydt(dy::X,y::T,p::V,t::Q) where {X,T,Q,V} = dydtreactor!(dy,y,t,domains,interfaces,p=p)
     jacy!(J::Q2,y::T,p::V,t::Q) where {Q2,T,Q,V} = jacobianyforwarddiff!(J,y,p,t,domains,interfaces,nothing)
     jacp!(J::Q2,y::T,p::V,t::Q) where {Q2,T,Q,V} = jacobianpforwarddiff!(J,y,p,t,domains,interfaces,nothing)
@@ -182,7 +182,7 @@ function Reactor(domains::T,y0s::W1,tspan::W2,interfaces::Z=Tuple(),ps::X=SciMLB
     psetupsundials(p::T1, t::T2, u::T3, du::T4, jok::Bool, jcurPtr::T5, gamma::T6) where {T1,T2,T3,T4,T5,T6} = _psetupsundials(p, t, u, du, jok, jcurPtr, gamma, jacy!, W::SparseMatrixCSC{Float64, Int64}, preccache::Base.RefValue{IncompleteLU.ILUFactorization{Float64, Int64}}, tau::Float64)
     precsundials(z::T1, r::T2, p::T3, t::T4, y::T5, fy::T6, gamma::T7, delta::T8, lr::T9) where {T1,T2,T3,T4,T5,T6,T7,T8,T9} = _precsundials(z, r, p, t, y, fy, gamma, delta, lr, preccache)
     precsjulia(W::T1,du::T2,u::T3,p::T4,t::T5,newW::T6,Plprev::T7,Prprev::T8,solverdata::T9) where {T1,T2,T3,T4,T5,T6,T7,T8,T9} =  _precsjulia(W,du,u,p,t,newW,Plprev,Prprev,solverdata,tau)
-    
+
     # determine worst sparsity
     y0length = length(y0)
     J = spzeros(y0length,y0length)
@@ -198,7 +198,7 @@ function Reactor(domains::T,y0s::W1,tspan::W2,interfaces::Z=Tuple(),ps::X=SciMLB
     @inbounds @views @. W[idxs] = W[idxs] + 1
     prectmp = ilu(W, τ = tau)
     preccache = Ref(prectmp)
-    
+
     if forwardsensitivities
         odefcn = ODEFunction(dydt;paramjac=jacp!)
         ode = ODEForwardSensitivityProblem(odefcn,y0,tspan,p)

--- a/src/Reactor.jl
+++ b/src/Reactor.jl
@@ -95,7 +95,7 @@ function Reactor(domains::T,y0s::W1,tspan::W2,interfaces::Z=Tuple(),ps::X=SciMLB
     for (j,domain) in enumerate(domains)
         Nspcs = length(domain.phase.species)
         Ntherm = length(domain.indexes) - 2
-        for i = 1:8, j = 1:size(domain.rxnarray)[2]
+        for i = 1:10, j = 1:size(domain.rxnarray)[2]
             if domain.rxnarray[i,j] != 0
                 domain.rxnarray[i,j] += k-1
             end
@@ -375,23 +375,27 @@ end
     Nprod = length(rxn.productinds)
     R = 0.0
     if Nreact == 1
-        @fastmath @inbounds R += kfs[rxn.index]*cs[rxn.reactantinds[1]]
+        @fastmath @inbounds R += kfs[rxn.index] * cs[rxn.reactantinds[1]]
     elseif Nreact == 2
-        @fastmath @inbounds R += kfs[rxn.index]*cs[rxn.reactantinds[1]]*cs[rxn.reactantinds[2]]
+        @fastmath @inbounds R += kfs[rxn.index] * cs[rxn.reactantinds[1]] * cs[rxn.reactantinds[2]]
     elseif Nreact == 3
-        @fastmath @inbounds R += kfs[rxn.index]*cs[rxn.reactantinds[1]]*cs[rxn.reactantinds[2]]*cs[rxn.reactantinds[3]]
+        @fastmath @inbounds R += kfs[rxn.index] * cs[rxn.reactantinds[1]] * cs[rxn.reactantinds[2]] * cs[rxn.reactantinds[3]]
     elseif Nreact == 4
-        @fastmath @inbounds R += kfs[rxn.index]*cs[rxn.reactantinds[1]]*cs[rxn.reactantinds[2]]*cs[rxn.reactantinds[3]]*cs[rxn.reactantinds[4]]
+        @fastmath @inbounds R += kfs[rxn.index] * cs[rxn.reactantinds[1]] * cs[rxn.reactantinds[2]] * cs[rxn.reactantinds[3]] * cs[rxn.reactantinds[4]]
+    elseif Nreact == 5
+        @fastmath @inbounds R += kfs[rxn.index] * cs[rxn.reactantinds[1]] * cs[rxn.reactantinds[2]] * cs[rxn.reactantinds[3]] * cs[rxn.reactantinds[4]] * cs[rxn.reactantinds[5]]
     end
 
     if Nprod == 1
-        @fastmath @inbounds R -= krevs[rxn.index]*cs[rxn.productinds[1]]
+        @fastmath @inbounds R -= krevs[rxn.index] * cs[rxn.productinds[1]]
     elseif Nprod == 2
-        @fastmath @inbounds R -= krevs[rxn.index]*cs[rxn.productinds[1]]*cs[rxn.productinds[2]]
+        @fastmath @inbounds R -= krevs[rxn.index] * cs[rxn.productinds[1]] * cs[rxn.productinds[2]]
     elseif Nprod == 3
-        @fastmath @inbounds R -= krevs[rxn.index]*cs[rxn.productinds[1]]*cs[rxn.productinds[2]]*cs[rxn.productinds[3]]
+        @fastmath @inbounds R -= krevs[rxn.index] * cs[rxn.productinds[1]] * cs[rxn.productinds[2]] * cs[rxn.productinds[3]]
     elseif Nprod == 4
-        @fastmath @inbounds R -= krevs[rxn.index]*cs[rxn.productinds[1]]*cs[rxn.productinds[2]]*cs[rxn.productinds[3]]*cs[rxn.productinds[4]]
+        @fastmath @inbounds R -= krevs[rxn.index] * cs[rxn.productinds[1]] * cs[rxn.productinds[2]] * cs[rxn.productinds[3]] * cs[rxn.productinds[4]]
+    elseif Nprod == 5
+        @fastmath @inbounds R -= krevs[rxn.index] * cs[rxn.productinds[1]] * cs[rxn.productinds[2]] * cs[rxn.productinds[3]] * cs[rxn.productinds[4]] * cs[rxn.productinds[5]]
     end
 
     return R
@@ -401,26 +405,30 @@ export getrate
 @inline function getrates(rarray,cs,kfs,krevs)
     rts = zeros(length(kfs))
     for i = 1:length(rts)
-        if @inbounds rarray[2,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]
-        elseif @inbounds rarray[3,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]
-        elseif @inbounds rarray[4,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]
+        if @inbounds rarray[2, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]]
+        elseif @inbounds rarray[3, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]]
+        elseif @inbounds rarray[4, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]]
+        elseif @inbounds rarray[5, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]]
         else
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]*cs[rarray[4,i]]
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]] * cs[rarray[5, i]]
         end
-        if @inbounds rarray[6,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]
-        elseif @inbounds rarray[7,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]
-        elseif @inbounds rarray[8,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]
+        if @inbounds rarray[7, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]]
+        elseif @inbounds rarray[8, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]]
+        elseif @inbounds rarray[9, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]]
+        elseif @inbounds rarray[10, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]]
         else
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]*cs[rarray[8,i]]
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]] * cs[rarray[10, i]]
         end
         @fastmath R = fR - rR
-        
+
         rts[i] = R
     end
     return rts
@@ -429,23 +437,27 @@ export getrates
 
 @inline function addreactionratecontributions!(dydt::Q,rarray::Array{W2,2},cs::W,kfs::Z,krevs::Y) where {Q,Z,Y,T,W,W2}
     @inbounds @simd for i = 1:size(rarray)[2]
-        if @inbounds rarray[2,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]
-        elseif @inbounds rarray[3,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]
-        elseif @inbounds rarray[4,i] == 0 
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]
+        if @inbounds rarray[2, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]]
+        elseif @inbounds rarray[3, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]]
+        elseif @inbounds rarray[4, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]]
+        elseif @inbounds rarray[5, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]]
         else
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]*cs[rarray[4,i]] 
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]] * cs[rarray[5, i]]
         end
-        if @inbounds rarray[6,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]
-        elseif @inbounds rarray[7,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]
-        elseif @inbounds rarray[8,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]
+        if @inbounds rarray[7, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]]
+        elseif @inbounds rarray[8, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]]
+        elseif @inbounds rarray[9, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]]
+        elseif @inbounds rarray[10, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]]
         else
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]*cs[rarray[8,i]]
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]] * cs[rarray[10, i]]
         end
         @fastmath R = fR - rR
         @inbounds @fastmath dydt[rarray[1,i]] -= R
@@ -455,16 +467,22 @@ export getrates
                 @inbounds @fastmath dydt[rarray[3,i]] -= R
                 if @inbounds rarray[4,i] != 0
                     @inbounds @fastmath dydt[rarray[4,i]] -= R
+                    if @inbounds rarray[5, i] != 0
+                        @inbounds @fastmath dydt[rarray[5, i]] -= R
+                    end
                 end
             end
         end
-        @inbounds @fastmath dydt[rarray[5,i]] += R
-        if @inbounds rarray[6,i] != 0
-            @inbounds @fastmath dydt[rarray[6,i]] += R
-            if @inbounds rarray[7,i] != 0
-                @inbounds @fastmath dydt[rarray[7,i]] += R
-                if @inbounds rarray[8,i] != 0
-                    @inbounds @fastmath dydt[rarray[8 ,i]] += R
+        @inbounds @fastmath dydt[rarray[6,i]] += R
+        if @inbounds rarray[7,i] != 0
+            @inbounds @fastmath dydt[rarray[7,i]] += R
+            if @inbounds rarray[8,i] != 0
+                @inbounds @fastmath dydt[rarray[8,i]] += R
+                if @inbounds rarray[9,i] != 0
+                    @inbounds @fastmath dydt[rarray[9 ,i]] += R
+                    if @inbounds rarray[10, i] != 0
+                        @inbounds @fastmath dydt[rarray[10, i]] += R
+                    end
                 end
             end
         end
@@ -473,23 +491,27 @@ end
 
 @inline function addreactionratecontributions!(dydt::Q,rarray::Array{W2,2},cs::W,kfs::Z,krevs::Y,V) where {Q,Z,Y,T,W,W2}
     @inbounds @simd for i = 1:size(rarray)[2]
-        if @inbounds rarray[2,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]
-        elseif @inbounds rarray[3,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]
-        elseif @inbounds rarray[4,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]
+        if @inbounds rarray[2, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]]
+        elseif @inbounds rarray[3, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]]
+        elseif @inbounds rarray[4, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]]
+        elseif @inbounds rarray[5, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]]
         else
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]*cs[rarray[4,i]]
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]] * cs[rarray[5, i]]
         end
-        if @inbounds rarray[6,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]
-        elseif @inbounds rarray[7,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]
-        elseif @inbounds rarray[8,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]
+        if @inbounds rarray[7, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]]
+        elseif @inbounds rarray[8, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]]
+        elseif @inbounds rarray[9, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]]
+        elseif @inbounds rarray[10, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]]
         else
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]*cs[rarray[8,i]]
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]] * cs[rarray[10, i]]
         end
         @fastmath R = (fR - rR)*V
         @inbounds @fastmath dydt[rarray[1,i]] -= R
@@ -499,16 +521,22 @@ end
                 @inbounds @fastmath dydt[rarray[3,i]] -= R
                 if @inbounds rarray[4,i] != 0
                     @inbounds @fastmath dydt[rarray[4,i]] -= R
+                    if @inbounds rarray[5, i] != 0
+                        @inbounds @fastmath dydt[rarray[5, i]] -= R
+                    end
                 end
             end
         end
-        @inbounds @fastmath dydt[rarray[5,i]] += R
-        if @inbounds rarray[6,i] != 0
-            @inbounds @fastmath dydt[rarray[6,i]] += R
-            if @inbounds rarray[7,i] != 0
-                @inbounds @fastmath dydt[rarray[7,i]] += R
-                if @inbounds rarray[8,i] != 0
-                    @inbounds @fastmath dydt[rarray[8,i]] += R
+        @inbounds @fastmath dydt[rarray[6,i]] += R
+        if @inbounds rarray[7,i] != 0
+            @inbounds @fastmath dydt[rarray[7,i]] += R
+            if @inbounds rarray[8,i] != 0
+                @inbounds @fastmath dydt[rarray[8,i]] += R
+                if @inbounds rarray[9, i] != 0
+                    @inbounds @fastmath dydt[rarray[9, i]] += R
+                    if @inbounds rarray[10, i] != 0
+                        @inbounds @fastmath dydt[rarray[10, i]] += R
+                    end
                 end
             end
         end
@@ -521,23 +549,27 @@ export addreactionratecontributions!
     rrts = zeros(length(kfs))
     rts = zeros(length(kfs))
     @inbounds for i = 1:size(rarray)[2]
-        if @inbounds rarray[2,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]
-        elseif @inbounds rarray[3,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]
-        elseif @inbounds rarray[4,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]
+        if @inbounds rarray[2, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]]
+        elseif @inbounds rarray[3, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]]
+        elseif @inbounds rarray[4, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]]
+        elseif @inbounds rarray[5, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]]
         else
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]*cs[rarray[4,i]]
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]] * cs[rarray[5, i]]
         end
-        if @inbounds rarray[6,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]
-        elseif @inbounds rarray[7,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]
-        elseif @inbounds rarray[8,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]
+        if @inbounds rarray[7, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]]
+        elseif @inbounds rarray[8, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]]
+        elseif @inbounds rarray[9, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]]
+        elseif @inbounds rarray[10, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]]
         else
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]*cs[rarray[8,i]]
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]] * cs[rarray[10, i]]
         end
         @inbounds @fastmath frts[i] = fR*V
         @inbounds @fastmath rrts[i] = rR*V
@@ -550,16 +582,22 @@ export addreactionratecontributions!
                 @inbounds @fastmath dydt[rarray[3,i]] -= R
                 if @inbounds rarray[4,i] != 0
                     @inbounds @fastmath dydt[rarray[4,i]] -= R
+                    if @inbounds rarray[5, i] != 0
+                        @inbounds @fastmath dydt[rarray[5, i]] -= R
+                    end
                 end
             end
         end
-        @inbounds @fastmath dydt[rarray[5,i]] += R
-        if @inbounds rarray[6,i] != 0
-            @inbounds @fastmath dydt[rarray[6,i]] += R
-            if @inbounds rarray[7,i] != 0
-                @inbounds @fastmath dydt[rarray[7,i]] += R
-                if @inbounds rarray[8,i] != 0
-                    @inbounds @fastmath dydt[rarray[8,i]] += R
+        @inbounds @fastmath dydt[rarray[6,i]] += R
+        if @inbounds rarray[7,i] != 0
+            @inbounds @fastmath dydt[rarray[7,i]] += R
+            if @inbounds rarray[8,i] != 0
+                @inbounds @fastmath dydt[rarray[8,i]] += R
+                if @inbounds rarray[9, i] != 0
+                    @inbounds @fastmath dydt[rarray[9, i]] += R
+                    if @inbounds rarray[10, i] != 0
+                        @inbounds @fastmath dydt[rarray[10, i]] += R
+                    end
                 end
             end
         end
@@ -787,13 +825,16 @@ end
 export jacobianp
 
 @inline function _spreadreactantpartials!(jac::S,deriv::Float64,rxnarray::Array{Int64,2},rxnind::Int64,ind::Int64) where {S<:AbstractArray}
-    @inbounds jac[rxnarray[5,rxnind],ind] += deriv
-    if @inbounds rxnarray[6,rxnind] !== 0
-        @inbounds jac[rxnarray[6,rxnind],ind] += deriv
-        if @inbounds rxnarray[7,rxnind] !== 0
-            @inbounds jac[rxnarray[7,rxnind],ind] += deriv
-            if @inbounds rxnarray[8,rxnind] !== 0
-                @inbounds jac[rxnarray[8,rxnind],ind] += deriv
+    @inbounds jac[rxnarray[6,rxnind],ind] += deriv
+    if @inbounds rxnarray[7,rxnind] !== 0
+        @inbounds jac[rxnarray[7,rxnind],ind] += deriv
+        if @inbounds rxnarray[8,rxnind] !== 0
+            @inbounds jac[rxnarray[8,rxnind],ind] += deriv
+            if @inbounds rxnarray[9,rxnind] !== 0
+                @inbounds jac[rxnarray[9,rxnind],ind] += deriv
+                if @inbounds rxnarray[10, rxnind] !== 0
+                    @inbounds jac[rxnarray[10, rxnind], ind] += deriv
+                end
             end
         end
     end
@@ -806,6 +847,9 @@ end
             @inbounds jac[rxnarray[3,rxnind],ind] += deriv
             if @inbounds rxnarray[4,rxnind] !== 0
                 @inbounds jac[rxnarray[4,rxnind],ind] += deriv
+                if @inbounds rxnarray[5, rxnind] !== 0
+                    @inbounds jac[rxnarray[5, rxnind], ind] += deriv
+                end
             end
         end
     end
@@ -832,7 +876,7 @@ end
             @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= deriv
             @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
         end
-    elseif rxnarray[4,rxnind] == 0 
+    elseif rxnarray[4,rxnind] == 0
         if rxnarray[1,rxnind]==rxnarray[2,rxnind] && rxnarray[1,rxnind]==rxnarray[3,rxnind]
             @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]
             @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 3.0*deriv
@@ -881,401 +925,2141 @@ end
             @inbounds jac[rxnarray[3,rxnind],rxnarray[3,rxnind]] -= deriv
             @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[3,rxnind])
         end
-    else
-        if rxnarray[1,rxnind]==rxnarray[2,rxnind] && rxnarray[1,rxnind]==rxnarray[3,rxnind] && rxnarray[1,rxnind]==rxnarray[4,rxnind]
-            @inbounds @fastmath deriv = 4.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 4.0*deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-        elseif rxnarray[1,rxnind]==rxnarray[2,rxnind] && rxnarray[1,rxnind]==rxnarray[3,rxnind] 
-            @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[4,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[4,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
-        elseif rxnarray[1,rxnind]==rxnarray[3,rxnind] && rxnarray[1,rxnind]==rxnarray[4,rxnind]
-            @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
-        elseif rxnarray[1,rxnind]==rxnarray[2,rxnind] && rxnarray[1,rxnind]==rxnarray[4,rxnind]
-            @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[3,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[3,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[3,rxnind])
-        elseif rxnarray[2,rxnind]==rxnarray[3,rxnind] && rxnarray[2,rxnind]==rxnarray[4,rxnind]
-            @inbounds @fastmath deriv = k*cs[rxnarray[2,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[2,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= 3.0*deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-            @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[2,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= 3.0*deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
-        elseif rxnarray[1,rxnind]==rxnarray[2,rxnind]
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[4,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[3,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[3,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[3,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[4,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[4,rxnind]] -= deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
-        elseif rxnarray[1,rxnind]==rxnarray[3,rxnind]
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[4,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[4,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[4,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[4,rxnind]] -= deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
-        elseif rxnarray[1,rxnind]==rxnarray[4,rxnind]
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[3,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[3,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[3,rxnind])
-        elseif rxnarray[2,rxnind]==rxnarray[3,rxnind]
-            @inbounds @fastmath deriv = k*cs[rxnarray[2,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[4,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= 2.0*dderiv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[4,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[2,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[4,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[4,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
-        elseif rxnarray[2,rxnind]==rxnarray[4,rxnind]
-            @inbounds @fastmath deriv = k*cs[rxnarray[2,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= 2.0*dderiv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[2,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[3,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[3,rxnind])
-        elseif rxnarray[3,rxnind]==rxnarray[4,rxnind]
-            @inbounds @fastmath deriv = k*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[3,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= dderiv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[1,rxnind]] -= 2.0*deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[3,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[2,rxnind]] -= 2.0*deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[3,rxnind]] -= 2.0*deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[3,rxnind])
+    elseif rxnarray[5,rxnind] == 0
+        if rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 4.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[3, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[3, rxnind] && rxnarray[2, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[3, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[2, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[4, rxnind] && rxnarray[2, rxnind] == rxnarray[3, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[3, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * dderiv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * dderiv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[3, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= dderiv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
         else
-            @inbounds @fastmath deriv = k*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[1,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[1,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[2,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[2,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[4,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[3,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[3,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]
-            @inbounds jac[rxnarray[1,rxnind],rxnarray[4,rxnind]] -= deriv
-            @inbounds jac[rxnarray[2,rxnind],rxnarray[4,rxnind]] -= deriv
-            @inbounds jac[rxnarray[3,rxnind],rxnarray[4,rxnind]] -= deriv
-            @inbounds jac[rxnarray[4,rxnind],rxnarray[4,rxnind]] -= deriv
-            @inbounds _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,rxnarray[4,rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        end
+    else
+        if rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind] && rxnarray[1, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 5.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 5.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind] && rxnarray[1, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind] && rxnarray[1, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[1, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[3, rxnind] && rxnarray[2, rxnind] == rxnarray[4, rxnind] && rxnarray[2, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 4.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 4.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[4, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind] && rxnarray[3, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[5, rxnind] && rxnarray[3, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind] && rxnarray[2, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[1, rxnind] == rxnarray[5, rxnind] && rxnarray[2, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[4, rxnind] && rxnarray[1, rxnind] == rxnarray[5, rxnind] && rxnarray[2, rxnind] == rxnarray[3, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[3, rxnind] && rxnarray[2, rxnind] == rxnarray[4, rxnind] && rxnarray[1, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[3, rxnind] && rxnarray[2, rxnind] == rxnarray[5, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[4, rxnind] && rxnarray[2, rxnind] == rxnarray[5, rxnind] && rxnarray[1, rxnind] == rxnarray[3, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+        elseif rxnarray[3, rxnind] == rxnarray[4, rxnind] && rxnarray[3, rxnind] == rxnarray[5, rxnind] && rxnarray[1, rxnind] == rxnarray[2, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[3, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[1, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[1, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[1, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[4, rxnind] && rxnarray[1, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[3, rxnind] && rxnarray[2, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[3, rxnind] && rxnarray[2, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[4, rxnind] && rxnarray[2, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[3, rxnind] == rxnarray[4, rxnind] && rxnarray[3, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[3, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[2, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[4, rxnind] && rxnarray[2, rxnind] == rxnarray[3, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[3, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[2, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[5, rxnind] && rxnarray[2, rxnind] == rxnarray[3, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind] && rxnarray[4, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[4, rxnind] && rxnarray[2, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[5, rxnind] && rxnarray[2, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind] && rxnarray[4, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[4, rxnind] && rxnarray[3, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[5, rxnind] && rxnarray[3, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[3, rxnind] && rxnarray[4, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[4, rxnind] && rxnarray[3, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[5, rxnind] && rxnarray[3, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[2, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[3, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[1, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[3, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[2, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[3, rxnind] == rxnarray[4, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[5, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
+        elseif rxnarray[3, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[3, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        elseif rxnarray[4, rxnind] == rxnarray[5, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+        else
+            @inbounds @fastmath deriv = k * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[1, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[1, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[2, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[2, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[3, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[3, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[5, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[4, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[4, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]]
+            @inbounds jac[rxnarray[1, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[2, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[3, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[4, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds jac[rxnarray[5, rxnind], rxnarray[5, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[5, rxnind])
         end
     end
     k=krev
-    if rxnarray[6,rxnind] == 0
+    if rxnarray[7, rxnind] == 0
         deriv = k
-        @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
-        @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-    elseif rxnarray[7,rxnind] == 0
-        if rxnarray[5,rxnind] == rxnarray[6,rxnind]
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[5,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
+        @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+        @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+    elseif rxnarray[8, rxnind] == 0
+        if rxnarray[6, rxnind] == rxnarray[7, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
         else
-            @inbounds @fastmath deriv = k*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
         end
-    elseif rxnarray[8,rxnind] == 0
-        if rxnarray[5,rxnind]==rxnarray[6,rxnind] && rxnarray[5,rxnind]==rxnarray[7,rxnind]
-            @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 3.0*deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-        elseif rxnarray[5,rxnind]==rxnarray[6,rxnind]
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[7,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[7,rxnind])
-        elseif rxnarray[6,rxnind]==rxnarray[7,rxnind]
-            @inbounds @fastmath deriv = k*cs[rxnarray[6,rxnind]]*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= 2.0*deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
-        elseif rxnarray[5,rxnind]==rxnarray[7,rxnind]
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
+    elseif rxnarray[9, rxnind] == 0
+        if rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
         else
-            @inbounds @fastmath deriv = k*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[7,rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        end
+    elseif rxnarray[10, rxnind] == 0
+        if rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 4.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[8, rxnind] && rxnarray[7, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[8, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[7, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[9, rxnind] && rxnarray[7, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[8, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        else
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadproductpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
         end
     else
-        if rxnarray[5,rxnind]==rxnarray[6,rxnind] && rxnarray[5,rxnind]==rxnarray[7,rxnind] && rxnarray[5,rxnind]==rxnarray[8,rxnind]
-            @inbounds @fastmath deriv = 4.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 4.0*deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-        elseif rxnarray[5,rxnind]==rxnarray[6,rxnind] && rxnarray[5,rxnind]==rxnarray[7,rxnind]
-            @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[8,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[8,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[8,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[8,rxnind])
-        elseif rxnarray[5,rxnind]==rxnarray[7,rxnind] && rxnarray[5,rxnind]==rxnarray[8,rxnind]
-            @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
-        elseif rxnarray[5,rxnind]==rxnarray[6,rxnind] && rxnarray[5,rxnind]==rxnarray[8,rxnind]
-            @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[7,rxnind]] -= 3.0*deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[7,rxnind])
-        elseif rxnarray[6,rxnind]==rxnarray[7,rxnind] && rxnarray[6,rxnind]==rxnarray[8,rxnind]
-            @inbounds @fastmath deriv = k*cs[rxnarray[6,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= 3.0*deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = 3.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= 3.0*deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
-        elseif rxnarray[5,rxnind]==rxnarray[6,rxnind]
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[8,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[7,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[7,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[8,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[8,rxnind]] -= deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[8,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[8,rxnind])
-        elseif rxnarray[5,rxnind]==rxnarray[7,rxnind]
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[8,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[8,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[8,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[8,rxnind]] -= deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[8,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[8,rxnind])
-        elseif rxnarray[5,rxnind]==rxnarray[8,rxnind]
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[7,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[7,rxnind])
-        elseif rxnarray[6,rxnind]==rxnarray[7,rxnind]
-            @inbounds @fastmath deriv = k*cs[rxnarray[6,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[8,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[8,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[8,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[8,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[8,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[8,rxnind])
-        elseif rxnarray[6,rxnind]==rxnarray[8,rxnind]
-            @inbounds @fastmath deriv = k*cs[rxnarray[6,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[6,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[7,rxnind]] -= 2.0*deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[7,rxnind])
-        elseif rxnarray[7,rxnind]==rxnarray[8,rxnind]
-            @inbounds @fastmath deriv = k*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[5,rxnind]] -= 2.0*deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[6,rxnind]] -= 2.0*deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
-            @inbounds @fastmath deriv = 2.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= 2.0*deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[7,rxnind])
+        if rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind] && rxnarray[6, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 5.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 5.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind] && rxnarray[6, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind] && rxnarray[6, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[6, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 4.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[8, rxnind] && rxnarray[7, rxnind] == rxnarray[9, rxnind] && rxnarray[7, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 4.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 4.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 4.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[9, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind] && rxnarray[8, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[10, rxnind] && rxnarray[8, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind] && rxnarray[7, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[6, rxnind] == rxnarray[10, rxnind] && rxnarray[7, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[9, rxnind] && rxnarray[6, rxnind] == rxnarray[10, rxnind] && rxnarray[7, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[8, rxnind] && rxnarray[7, rxnind] == rxnarray[9, rxnind] && rxnarray[6, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[8, rxnind] && rxnarray[7, rxnind] == rxnarray[10, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[9, rxnind] && rxnarray[7, rxnind] == rxnarray[10, rxnind] && rxnarray[6, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+        elseif rxnarray[8, rxnind] == rxnarray[9, rxnind] && rxnarray[8, rxnind] == rxnarray[10, rxnind] && rxnarray[6, rxnind] == rxnarray[7, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[6, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[6, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[6, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[9, rxnind] && rxnarray[6, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[8, rxnind] && rxnarray[7, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[8, rxnind] && rxnarray[7, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[9, rxnind] && rxnarray[7, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= 3.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[8, rxnind] == rxnarray[9, rxnind] && rxnarray[8, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = 3.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 3.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[8, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[7, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[9, rxnind] && rxnarray[7, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[8, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[7, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[10, rxnind] && rxnarray[7, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind] && rxnarray[9, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[9, rxnind] && rxnarray[7, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[10, rxnind] && rxnarray[7, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind] && rxnarray[9, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[9, rxnind] && rxnarray[8, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[10, rxnind] && rxnarray[8, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[8, rxnind] && rxnarray[9, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[9, rxnind] && rxnarray[8, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[10, rxnind] && rxnarray[8, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[7, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[6, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[8, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[7, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[8, rxnind] == rxnarray[9, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[10, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
+        elseif rxnarray[8, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[8, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+        elseif rxnarray[9, rxnind] == rxnarray[10, rxnind]
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = 2.0 * k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= 2.0 * deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
         else
-            @inbounds @fastmath deriv = k*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[5,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[5,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[6,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[6,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[8,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[7,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[7,rxnind])
-            @inbounds @fastmath deriv = k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
-            @inbounds jac[rxnarray[5,rxnind],rxnarray[8,rxnind]] -= deriv
-            @inbounds jac[rxnarray[6,rxnind],rxnarray[8,rxnind]] -= deriv
-            @inbounds jac[rxnarray[7,rxnind],rxnarray[8,rxnind]] -= deriv
-            @inbounds jac[rxnarray[8,rxnind],rxnarray[8,rxnind]] -= deriv
-            @inbounds _spreadproductpartials!(jac,deriv,rxnarray,rxnind,rxnarray[8,rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[6, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[6, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[7, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[7, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[8, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[8, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[10, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[9, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[9, rxnind])
+            @inbounds @fastmath deriv = k * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]]
+            @inbounds jac[rxnarray[6, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[7, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[8, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[9, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds jac[rxnarray[10, rxnind], rxnarray[10, rxnind]] -= deriv
+            @inbounds _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, rxnarray[10, rxnind])
         end
     end
 end
@@ -1295,34 +3079,50 @@ end
         @inbounds jac[rxnarray[2,rxnind],Vind] -= deriv
         @inbounds jac[rxnarray[3,rxnind],Vind] -= deriv
         _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,Vind)
-    else
-        @inbounds @fastmath deriv = -3.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]
+    elseif rxnarray[5,rxnind]== 0
+        @inbounds @fastmath deriv = -3.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[3,rxnind]]
         @inbounds jac[rxnarray[1,rxnind],Vind] -= deriv
         @inbounds jac[rxnarray[2,rxnind],Vind] -= deriv
         @inbounds jac[rxnarray[3,rxnind],Vind] -= deriv
         @inbounds jac[rxnarray[4,rxnind],Vind] -= deriv
-        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,Vind) 
+        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,Vind)
+    else
+        @inbounds @fastmath deriv = -4.0*k*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]*cs[rxnarray[5,rxnind]]
+        @inbounds jac[rxnarray[1,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[2,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[3,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[4,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[5,rxnind],Vind] -= deriv
+        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,Vind)
     end
     k=krev
-    if rxnarray[6,rxnind]==0
+    if rxnarray[7,rxnind]==0
         nothing
-    elseif rxnarray[7,rxnind] == 0
-        @inbounds @fastmath deriv = -k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]
-        @inbounds jac[rxnarray[5,rxnind],Vind] -= deriv
-        @inbounds jac[rxnarray[6,rxnind],Vind] -= deriv
-        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,Vind)
     elseif rxnarray[8,rxnind] == 0
-        @inbounds @fastmath deriv = -2.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
-        @inbounds jac[rxnarray[5,rxnind],Vind] -= deriv
+        @inbounds @fastmath deriv = -k*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]
         @inbounds jac[rxnarray[6,rxnind],Vind] -= deriv
         @inbounds jac[rxnarray[7,rxnind],Vind] -= deriv
         _spreadproductpartials!(jac,deriv,rxnarray,rxnind,Vind)
-    else
-        @inbounds @fastmath deriv = -3.0*k*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]
-        @inbounds jac[rxnarray[5,rxnind],Vind] -= deriv
+    elseif rxnarray[9,rxnind] == 0
+        @inbounds @fastmath deriv = -2.0*k*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]
         @inbounds jac[rxnarray[6,rxnind],Vind] -= deriv
         @inbounds jac[rxnarray[7,rxnind],Vind] -= deriv
         @inbounds jac[rxnarray[8,rxnind],Vind] -= deriv
+        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,Vind)
+    elseif rxnarray[10,rxnind] == 0
+        @inbounds @fastmath deriv = -3.0*k*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]*cs[rxnarray[9,rxnind]]
+        @inbounds jac[rxnarray[6,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[7,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[8,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[9,rxnind],Vind] -= deriv
+        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,Vind)
+    else
+        @inbounds @fastmath deriv = -4.0*k*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]*cs[rxnarray[9,rxnind]]*cs[rxnarray[10,rxnind]]
+        @inbounds jac[rxnarray[6,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[7,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[8,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[9,rxnind],Vind] -= deriv
+        @inbounds jac[rxnarray[10,rxnind],Vind] -= deriv
         _spreadproductpartials!(jac,deriv,rxnarray,rxnind,Vind) 
     end
 end
@@ -1332,52 +3132,68 @@ This function calculates the ns partials in jacobiany involving k derivatives. d
 """
 @inline function _jacobianykderiv!(jac::S,xind::Int64,dkfdx::Float64,dkrevdx::Float64,rxnarray::Array{Int64,2},rxnind::Int64,cs::Array{Float64,1},V::Float64) where {S<:AbstractArray}
     dkdx = dkfdx
-    if rxnarray[2,rxnind] == 0
-        @inbounds @fastmath deriv = dkdx*cs[rxnarray[1,rxnind]]*V
-        @inbounds jac[rxnarray[1,rxnind],xind] -= deriv
-        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,xind)
-    elseif rxnarray[3,rxnind] == 0
-        @inbounds @fastmath deriv = dkdx*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*V
-        @inbounds jac[rxnarray[1,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[2,rxnind],xind] -= deriv
-        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,xind)
-    elseif rxnarray[4,rxnind] == 0
-        @inbounds @fastmath deriv = dkdx*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*V
-        @inbounds jac[rxnarray[1,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[2,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[3,rxnind],xind] -= deriv
-        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,xind)
+    if rxnarray[2, rxnind] == 0
+        @inbounds @fastmath deriv = dkdx * cs[rxnarray[1, rxnind]] * V
+        @inbounds jac[rxnarray[1, rxnind], xind] -= deriv
+        _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, xind)
+    elseif rxnarray[3, rxnind] == 0
+        @inbounds @fastmath deriv = dkdx * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * V
+        @inbounds jac[rxnarray[1, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[2, rxnind], xind] -= deriv
+        _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, xind)
+    elseif rxnarray[4, rxnind] == 0
+        @inbounds @fastmath deriv = dkdx * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * V
+        @inbounds jac[rxnarray[1, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[2, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[3, rxnind], xind] -= deriv
+        _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, xind)
+    elseif rxnarray[5, rxnind] == 0
+        @inbounds @fastmath deriv = dkdx * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]] * V
+        @inbounds jac[rxnarray[1, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[2, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[3, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[4, rxnind], xind] -= deriv
+        _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, xind)
     else
-        @inbounds @fastmath deriv = dkdx*cs[rxnarray[1,rxnind]]*cs[rxnarray[2,rxnind]]*cs[rxnarray[3,rxnind]]*cs[rxnarray[4,rxnind]]*V
-        @inbounds jac[rxnarray[1,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[2,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[3,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[4,rxnind],xind] -= deriv
-        _spreadreactantpartials!(jac,deriv,rxnarray,rxnind,xind)
+        @inbounds @fastmath deriv = dkdx * cs[rxnarray[1, rxnind]] * cs[rxnarray[2, rxnind]] * cs[rxnarray[3, rxnind]] * cs[rxnarray[4, rxnind]] * cs[rxnarray[5, rxnind]] * V
+        @inbounds jac[rxnarray[1, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[2, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[3, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[4, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[5, rxnind], xind] -= deriv
+        _spreadreactantpartials!(jac, deriv, rxnarray, rxnind, xind)
     end
     dkdx = dkrevdx
-    if rxnarray[6,rxnind] == 0
-        @inbounds @fastmath deriv = dkdx*cs[rxnarray[5,rxnind]]*V
-        @inbounds jac[rxnarray[5,rxnind],xind] -= deriv
-        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,xind)
-    elseif rxnarray[7,rxnind] == 0
-        @inbounds @fastmath deriv = dkdx*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*V
-        @inbounds jac[rxnarray[5,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[6,rxnind],xind] -= deriv
-        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,xind)
-    elseif rxnarray[8,rxnind] == 0
-        @inbounds @fastmath deriv = dkdx*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*V
-        @inbounds jac[rxnarray[5,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[6,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[7,rxnind],xind] -= deriv
-        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,xind)
+    if rxnarray[7, rxnind] == 0
+        @inbounds @fastmath deriv = dkdx * cs[rxnarray[6, rxnind]] * V
+        @inbounds jac[rxnarray[6, rxnind], xind] -= deriv
+        _spreadproductpartials!(jac, deriv, rxnarray, rxnind, xind)
+    elseif rxnarray[8, rxnind] == 0
+        @inbounds @fastmath deriv = dkdx * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * V
+        @inbounds jac[rxnarray[6, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[7, rxnind], xind] -= deriv
+        _spreadproductpartials!(jac, deriv, rxnarray, rxnind, xind)
+    elseif rxnarray[9, rxnind] == 0
+        @inbounds @fastmath deriv = dkdx * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * V
+        @inbounds jac[rxnarray[6, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[7, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[8, rxnind], xind] -= deriv
+        _spreadproductpartials!(jac, deriv, rxnarray, rxnind, xind)
+    elseif rxnarray[10, rxnind] == 0
+        @inbounds @fastmath deriv = dkdx * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]] * V
+        @inbounds jac[rxnarray[6, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[7, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[8, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[9, rxnind], xind] -= deriv
+        _spreadproductpartials!(jac, deriv, rxnarray, rxnind, xind)
     else
-        @inbounds @fastmath deriv = dkdx*cs[rxnarray[5,rxnind]]*cs[rxnarray[6,rxnind]]*cs[rxnarray[7,rxnind]]*cs[rxnarray[8,rxnind]]*V
-        @inbounds jac[rxnarray[5,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[6,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[7,rxnind],xind] -= deriv
-        @inbounds jac[rxnarray[8,rxnind],xind] -= deriv
-        _spreadproductpartials!(jac,deriv,rxnarray,rxnind,xind)
+        @inbounds @fastmath deriv = dkdx * cs[rxnarray[6, rxnind]] * cs[rxnarray[7, rxnind]] * cs[rxnarray[8, rxnind]] * cs[rxnarray[9, rxnind]] * cs[rxnarray[10, rxnind]] * V
+        @inbounds jac[rxnarray[6, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[7, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[8, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[9, rxnind], xind] -= deriv
+        @inbounds jac[rxnarray[10, rxnind], xind] -= deriv
+        _spreadproductpartials!(jac, deriv, rxnarray, rxnind, xind)
     end
 end
 

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -352,26 +352,30 @@ export rops
 
 function rops!(ropmat,rarray,cs,kfs,krevs,V,start)
     for i = 1:length(kfs)
-        if @inbounds rarray[2,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]
-        elseif @inbounds rarray[3,i] == 0
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]
-        elseif @inbounds rarray[4,i] == 0 
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]
+        if @inbounds rarray[2, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]]
+        elseif @inbounds rarray[3, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]]
+        elseif @inbounds rarray[4, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]]
+        elseif @inbounds rarray[5, i] == 0
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]]
         else
-            @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]*cs[rarray[4,i]]  
+            @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]] * cs[rarray[5, i]]
         end
-        if @inbounds rarray[6,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]
-        elseif @inbounds rarray[7,i] == 0
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]
-        elseif rarray[8,i] == 0 
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]
+        if @inbounds rarray[7, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]]
+        elseif @inbounds rarray[8, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]]
+        elseif @inbounds rarray[9, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]]
+        elseif @inbounds rarray[10, i] == 0
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]]
         else
-            @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]*cs[rarray[8,i]]
+            @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]] * cs[rarray[10, i]]
         end
         @fastmath R = (fR - rR)*V
-        
+
         @inbounds @fastmath ropmat[i+start,rarray[1,i]] -= R
         if @inbounds rarray[2,i] != 0
             @inbounds @fastmath ropmat[i+start,rarray[2,i]] -= R
@@ -379,43 +383,53 @@ function rops!(ropmat,rarray,cs,kfs,krevs,V,start)
                 @inbounds @fastmath ropmat[i+start,rarray[3,i]] -= R
                 if @inbounds rarray[4,i] != 0
                     @inbounds @fastmath ropmat[i+start,rarray[4,i]] -= R
+                    if @inbounds rarray[5, i] != 0
+                        @inbounds @fastmath ropmat[i+start, rarray[5, i]] -= R
+                    end
                 end
             end
         end
-        @inbounds @fastmath ropmat[i+start,rarray[5,i]] += R
-        if @inbounds rarray[6,i] != 0
-            @inbounds @fastmath ropmat[i+start,rarray[6,i]] += R
-            if @inbounds rarray[7,i] != 0
-                @inbounds @fastmath ropmat[i+start,rarray[7,i]] += R
-                if @inbounds rarray[8,i] != 0
-                    @inbounds @fastmath ropmat[i+start,rarray[8,i]] += R
-                end 
+        @inbounds @fastmath ropmat[i+start,rarray[6,i]] += R
+        if @inbounds rarray[7,i] != 0
+            @inbounds @fastmath ropmat[i+start,rarray[7,i]] += R
+            if @inbounds rarray[8,i] != 0
+                @inbounds @fastmath ropmat[i+start,rarray[8,i]] += R
+                if @inbounds rarray[9,i] != 0
+                    @inbounds @fastmath ropmat[i+start,rarray[9,i]] += R
+                    if @inbounds rarray[10, i] != 0
+                        @inbounds @fastmath ropmat[i+start, rarray[10, i]] += R
+                    end
+                end
             end
-        end   
+        end
     end
 end
 
 function rops!(ropvec,rarray,cs,kfs,krevs,V,start,ind)
     for i = 1:length(kfs)
-        c = count(isequal(ind),rarray[5:8,i])-count(isequal(ind),rarray[1:4,i])
+        c = count(isequal(ind),rarray[6:10,i])-count(isequal(ind),rarray[1:5,i])
         if c != 0.0
-            if @inbounds rarray[2,i] == 0
-                @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]
-            elseif @inbounds rarray[3,i] == 0
-                @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]
-            elseif @inbounds rarray[4,i] == 0 
-                @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]
+            if @inbounds rarray[2, i] == 0
+                @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]]
+            elseif @inbounds rarray[3, i] == 0
+                @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]]
+            elseif @inbounds rarray[4, i] == 0
+                @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]]
+            elseif @inbounds rarray[5, i] == 0
+                @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]]
             else
-                @inbounds @fastmath fR = kfs[i]*cs[rarray[1,i]]*cs[rarray[2,i]]*cs[rarray[3,i]]*cs[rarray[4,i]]  
+                @inbounds @fastmath fR = kfs[i] * cs[rarray[1, i]] * cs[rarray[2, i]] * cs[rarray[3, i]] * cs[rarray[4, i]] * cs[rarray[5, i]]
             end
-            if @inbounds rarray[6,i] == 0
-                @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]
-            elseif @inbounds rarray[7,i] == 0
-                @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]
-            elseif rarray[8,i] == 0 
-                @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]
+            if @inbounds rarray[7, i] == 0
+                @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]]
+            elseif @inbounds rarray[8, i] == 0
+                @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]]
+            elseif @inbounds rarray[9, i] == 0
+                @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]]
+            elseif @inbounds rarray[10, i] == 0
+                @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]]
             else
-                @inbounds @fastmath rR = krevs[i]*cs[rarray[5,i]]*cs[rarray[6,i]]*cs[rarray[7,i]]*cs[rarray[8,i]]
+                @inbounds @fastmath rR = krevs[i] * cs[rarray[6, i]] * cs[rarray[7, i]] * cs[rarray[8, i]] * cs[rarray[9, i]] * cs[rarray[10, i]]
             end
             @fastmath R = (fR - rR)*V
             @fastmath @inbounds ropvec[i+start] = c*R
@@ -430,8 +444,8 @@ Calculates sensitivities with respect to `target` at the time point at the end o
 The returned sensitivities are the normalized values
 
 By default uses the InterpolatingAdjoint algorithm with vector Jacobian products calculated with ReverseDiffVJP(true)
-this assumes no changes in code branching during simulation, if that were to become no longer true, the Tracker 
-based alternative algorithm is slower, but avoids this concern. 
+this assumes no changes in code branching during simulation, if that were to become no longer true, the Tracker
+based alternative algorithm is slower, but avoids this concern.
 """
 function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(false)),
     abstol::Float64=1e-6,reltol::Float64=1e-3,normalize=true,kwargs...) where {Q,W,W2}
@@ -458,45 +472,45 @@ function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=In
             ind = findfirst(isequal(target),sensspcnames)
         end
     end
-    
+
     function sensg(y::X,p::Array{Y,1},t::Z) where {Q,V,X,Y<:Float64,Z}
         sensy = y[yinds]
         sensp = p[pinds]
         dy = similar(sensy,length(sensy))
         return dydtreactor!(dy,sensy,t,sensdomain,[],p=sensp)[ind]
     end
-    function sensg(y::Array{X,1},p::Y,t::Z) where {Q,V,X<:Float64,Y,Z} 
+    function sensg(y::Array{X,1},p::Y,t::Z) where {Q,V,X<:Float64,Y,Z}
         sensy = y[yinds]
         sensp = p[pinds]
         dy = similar(sensp,length(sensy))
         return dydtreactor!(dy,sensy,t,sensdomain,[],p=sensp)[ind]
     end
-    function sensg(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:Float64,Y<:Float64,Z} 
+    function sensg(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:Float64,Y<:Float64,Z}
         sensy = y[yinds]
         sensp = p[pinds]
         dy = similar(sensy,length(sensy))
         return dydtreactor!(dy,sensy,t,sensdomain,[],p=sensp)[ind]
     end
-    function sensg(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:ForwardDiff.Dual,Y<:ForwardDiff.Dual,Z} 
+    function sensg(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:ForwardDiff.Dual,Y<:ForwardDiff.Dual,Z}
         sensy = y[yinds]
         sensp = p[pinds]
         dy = similar(sensy,length(sensy))
         return dydtreactor!(dy,sensy,t,sensdomain,[],p=sensp)[ind]
     end
-    
-    function g(y::X,p::Array{Y,1},t::Z) where {Q,V,X,Y<:Float64,Z} 
+
+    function g(y::X,p::Array{Y,1},t::Z) where {Q,V,X,Y<:Float64,Z}
         dy = similar(y,length(y))
         return dydtreactor!(dy,y,t,bsol.domain,bsol.interfaces,p=p)[ind]
     end
-    function g(y::Array{X,1},p::Y,t::Z) where {Q,V,X<:Float64,Y,Z} 
+    function g(y::Array{X,1},p::Y,t::Z) where {Q,V,X<:Float64,Y,Z}
         dy = similar(p,length(y))
         return dydtreactor!(dy,y,t,bsol.domain,bsol.interfaces,p=p)[ind]
     end
-    function g(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:Float64,Y<:Float64,Z} 
+    function g(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:Float64,Y<:Float64,Z}
         dy = zeros(length(y))
         return dydtreactor!(dy,y,t,bsol.domain,bsol.interfaces,p=p)[ind]
     end
-    function g(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:ForwardDiff.Dual,Y<:ForwardDiff.Dual,Z} 
+    function g(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:ForwardDiff.Dual,Y<:ForwardDiff.Dual,Z}
         dy = similar(y,length(y))
         return dydtreactor!(dy,y,t,bsol.domain,bsol.interfaces,p=p)[ind]
     end
@@ -509,7 +523,7 @@ function getadjointsensitivities(bsol::Q,target::String,solver::W;sensalg::W2=In
     dsensgdprevdiff(out, y, p, t) = ReverseDiff.gradient!(out, p -> sensg(y, p, t), p)
     dgdurevdiff(out, y, p, t) = ReverseDiff.gradient!(out, y -> g(y, p, t), y)
     dgdprevdiff(out, y, p, t) = ReverseDiff.gradient!(out, p -> g(y, p, t), p)
-    
+
     if length(bsol.domain.p)<= pethane
         if target in ["T","V","P"] || !isempty(bsol.interfaces)
             du0,dpadj = adjoint_sensitivities(bsol.sol,solver,g,nothing,(dgdu,dgdp);sensealg=sensalg,abstol=abstol,reltol=reltol,kwargs...)
@@ -547,19 +561,19 @@ function getadjointsensitivities(syssim::Q,bsol::W3,target::String,solver::W;sen
         ind = findfirst(isequal(target),bsol.names)+bsol.domain.indexes[1]-1
     end
     domains = Tuple([x.domain for x in syssim.sims])
-    function g(y::X,p::Array{Y,1},t::Z) where {Q,V,X,Y<:Float64,Z} 
+    function g(y::X,p::Array{Y,1},t::Z) where {Q,V,X,Y<:Float64,Z}
         dy = similar(y,length(y))
         return dydtreactor!(dy,y,t,domains,syssim.interfaces,p=p)[ind]
     end
-    function g(y::Array{X,1},p::Y,t::Z) where {Q,V,X<:Float64,Y,Z} 
+    function g(y::Array{X,1},p::Y,t::Z) where {Q,V,X<:Float64,Y,Z}
         dy = similar(p,length(y))
         return dydtreactor!(dy,y,t,domains,syssim.interfaces,p=p)[ind]
     end
-    function g(y::Array{Float64,1},p::Array{Float64,1},t::Z) where {Q,V,Z} 
+    function g(y::Array{Float64,1},p::Array{Float64,1},t::Z) where {Q,V,Z}
         dy = similar(p,length(y))
         return dydtreactor!(dy,y,t,domains,syssim.interfaces,p=p)[ind]
     end
-    function g(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:ForwardDiff.Dual,Y<:ForwardDiff.Dual,Z} 
+    function g(y::Array{X,1},p::Array{Y,1},t::Z) where {Q,V,X<:ForwardDiff.Dual,Y<:ForwardDiff.Dual,Z}
         dy = similar(y,length(y))
         return dydtreactor!(dy,y,t,domains,syssim.interfaces,p=p)[ind]
     end
@@ -568,7 +582,7 @@ function getadjointsensitivities(syssim::Q,bsol::W3,target::String,solver::W;sen
     du0,dpadj = adjoint_sensitivities(syssim.sol,solver,g,nothing,(dgdu,dgdp);sensealg=sensalg,abstol=abstol,reltol=reltol,kwargs...)
     if normalize
         for domain in domains
-           dpadj[domain.parameterindexes[1]+length(domain.phase.species):domain.parameterindexes[2]] .*= syssim.p[domain.parameterindexes[1]+length(domain.phase.species):domain.parameterindexes[2]]
+            dpadj[domain.parameterindexes[1]+length(domain.phase.species):domain.parameterindexes[2]] .*= syssim.p[domain.parameterindexes[1]+length(domain.phase.species):domain.parameterindexes[2]]
         end
         if !(target in ["T","V","P"])
             dpadj ./= bsol.sol(bsol.sol.t[end])[ind]
@@ -583,7 +597,7 @@ function getconcentrationsensitivity(bsol::Simulation{Q,W,L,G}, numerator::Strin
     @assert denominator in bsol.names
     indnum = findfirst(isequal(numerator),bsol.names)+bsol.domain.indexes[1]-1
     inddeno = findfirst(isequal(denominator),bsol.names)+bsol.domain.parameterindexes[1]-1
-    Nvars = length(bsol.domain.phase.species)+length(bsol.domain.indexes)-2 
+    Nvars = length(bsol.domain.phase.species)+length(bsol.domain.indexes)-2
     Nrxns = length(bsol.domain.phase.reactions)
     x,dp = extract_local_sensitivities(bsol.sol,t)
     s = dp[inddeno][indnum]
@@ -600,7 +614,7 @@ function getconcentrationsensitivity(bsol::Simulation{Q,W,L,G}, numerator::Strin
     @assert denominator in bsol.names
     indnum = findfirst(isequal(numerator),bsol.names)+bsol.domain.indexes[1]-1
     inddeno = findfirst(isequal(denominator),bsol.names)+bsol.domain.parameterindexes[1]-1
-    Nvars = length(bsol.domain.phase.species)+length(bsol.domain.indexes)-2 
+    Nvars = length(bsol.domain.phase.species)+length(bsol.domain.indexes)-2
     Nrxns = length(bsol.domain.phase.reactions)
     x,dp = extract_local_sensitivities(bsol.sol,t)
     svals = dp[inddeno][bsol.domain.indexes[1]:bsol.domain.indexes[2]]
@@ -619,7 +633,7 @@ function getconcentrationsensitivity(bsol::Simulation{Q,W,L,G}, numerator::Strin
     @assert numerator in bsol.names
     indnum = findfirst(isequal(numerator),bsol.names)+bsol.domain.indexes[1]-1
     inddeno = denominator+bsol.domain.parameterindexes[1]-1
-    Nvars = length(bsol.domain.phase.species)+length(bsol.domain.indexes)-2 
+    Nvars = length(bsol.domain.phase.species)+length(bsol.domain.indexes)-2
     Nrxns = length(bsol.domain.phase.reactions)
     x,dp = extract_local_sensitivities(bsol.sol,t)
     s = dp[inddeno+length(bsol.domain.phase.species)][indnum]
@@ -639,7 +653,7 @@ function getconcentrationsensitivity(bsol::Simulation{Q,W,L,G}, numerator::Strin
     @assert numerator in bsol.names
     indnum = findfirst(isequal(numerator),bsol.names)+bsol.domain.indexes[1]-1
     inddeno = denominator+bsol.domain.parameterindexes[1]-1
-    Nvars = length(bsol.domain.phase.species)+length(bsol.domain.indexes)-2 
+    Nvars = length(bsol.domain.phase.species)+length(bsol.domain.indexes)-2
     Nrxns = length(bsol.domain.phase.reactions)
     x,dp = extract_local_sensitivities(bsol.sol,t)
     svals = dp[inddeno+length(bsol.domain.phase.species)][bsol.domain.indexes[1]:bsol.domain.indexes[2]]

--- a/src/TransitorySensitivities.jl
+++ b/src/TransitorySensitivities.jl
@@ -507,7 +507,7 @@ function transitorysensitivitiesadjointapprox(sim::Simulation,t,name;tau=NaN,
     end
 
     if tau == 0.0
-        dSdt = jacobianp(sim.sol,t,sim.ps)[ind,:];
+        dSdt = jacobianp(sim.sol,t,sim.p)[ind,:];
     else
         prob = remake(sim.sol.prob;u0=sim.sol(t),tspan=(0.0,tau));
         soladj = solve(prob,solver,reltol=reltol,abstol=abstol);


### PR DESCRIPTION
In rare cases, some models (e.g., from KAUST or NUIG) have 5 reactants/products. Since Chemkin/Cantera is able to deal with such cases, I think RMS should support it as well. 

This PR follows how things are done in PR #193. Given the current architecture of RMS, the major challenges come from getting the correct jacobian for reactions with 5 parties involved. I typed these manually in the hope of being error-free. This will also be the major challenge of this PR review. 