### PR TITLE
Convert Dict{Any,Any} to Dict{Symbol,Float64} for pyrms compatibility + formatting

### DIFF
--- a/src/ThreadedSensitivities.jl
+++ b/src/ThreadedSensitivities.jl
@@ -52,23 +52,23 @@ with odesolver, senssolver, odekwargs and senskwargs
 returns a dictionary mapping the index of the parameter to the ODESolution object
 corresponding to the associated sensitivities of every variable to that parameter
 """
-function threadedsensitivities(react,paramindices; odesolver=nothing,senssolver=nothing,
-        odekwargs=Dict([:abstol=>1e-20,:reltol=>1e-6]),senskwargs=Dict([:abstol=>1e-6,:reltol=>1e-3]))
+function threadedsensitivities(react, paramindices; odesolver=nothing, senssolver=nothing,
+    odekwargs=Dict([:abstol => 1e-20, :reltol => 1e-6]), senskwargs=Dict([:abstol => 1e-6, :reltol => 1e-3]))
 
-    if odesolver===nothing
+    if odesolver === nothing
         odesolver = react.recommendedsolver
     end
-    if senssolver===nothing
+    if senssolver === nothing
         senssolver = react.recommendedsolver
     end
 
     sol = solve(react.ode, odesolver; odekwargs...)
 
-    reactsens = Reactor(react.domain,react.y0,react.tspan,react.interfaces; p=react.p,
-                forwardsensitivities=true,forwarddiff=react.forwarddiff,modelingtoolkit=react.modelingtoolkit,
-                tau=react.tau)
+    reactsens = Reactor(react.domain, react.y0, react.tspan, react.interfaces; p=react.p,
+        forwardsensitivities=true, forwarddiff=react.forwarddiff, modelingtoolkit=react.modelingtoolkit,
+        tau=react.tau)
 
-    salist = generatesensitivityodes(react,sol)
+    salist = generatesensitivityodes(react, sol)
 
     # Parallelize the SA calculations
     solutiondictionary = Dict()

--- a/src/ThreadedSensitivities.jl
+++ b/src/ThreadedSensitivities.jl
@@ -53,7 +53,8 @@ returns a dictionary mapping the index of the parameter to the ODESolution objec
 corresponding to the associated sensitivities of every variable to that parameter
 """
 function threadedsensitivities(react, paramindices; odesolver=nothing, senssolver=nothing,
-    odekwargs=Dict([:abstol => 1e-20, :reltol => 1e-6]), senskwargs=Dict([:abstol => 1e-6, :reltol => 1e-3]))
+    odekwargs::Dict{Symbol,T1}=Dict([:abstol => 1e-20, :reltol => 1e-6]),
+    senskwargs::Dict{Symbol,T2}=Dict([:abstol => 1e-6, :reltol => 1e-3])) where {T1,T2}
 
     if odesolver === nothing
         odesolver = react.recommendedsolver
@@ -80,6 +81,18 @@ function threadedsensitivities(react, paramindices; odesolver=nothing, senssolve
 
     return solutiondictionary
 end
+
+function threadedsensitivities(react, paramindices; odesolver=nothing, senssolver=nothing,
+    odekwargs::Dict{Any,Any},
+    senskwargs::Dict{Any,Any})
+    # Convert to Dict{Symbol, T}
+    # Needed for pyrms compatability: Python string gets converted to String and runs into expected Symbol, got a value of type String error
+    odekwargs = Dict(Symbol(key) => value for (key, value) in odekwargs)
+    senskwargs = Dict(Symbol(key) => value for (key, value) in senskwargs)
+    return threadedsensitivities(react, paramindices; odesolver=odesolver, senssolver=senssolver,
+        odekwargs=odekwargs, senskwargs=senskwargs)
+end
+
 export threadedsensitivities
 
 """


### PR DESCRIPTION
This is needed for pyrms compatability, see https://github.com/ReactionMechanismGenerator/pyrms/pull/6.
Python string gets converted to String and runs into "expected Symbol, got a value of type String" error.
I tried the trick mentioned in https://github.com/JuliaPy/pyjulia/issues/156, but when the symbol is contained in a dictionary, it still gets converted to a String during python to Julia conversion.