### PR TITLE
Fix fragment smiles parser and refactor fragment adjlist parser

### DIFF
--- a/src/Parse.jl
+++ b/src/Parse.jl
@@ -169,16 +169,11 @@ function getatomdictadjlist(adjlist)
     _ , cutting_label_list = fragment.Fragment().detect_cutting_label(adjlist)
     if isempty(cutting_label_list)
         mol = molecule.Molecule().from_adjacency_list(adjlist)
+        getatomdictfromrmg(mol)
     else
         mol = fragment.Fragment().from_adjacency_list(adjlist)
-    end
-    if pybuiltin(:isinstance)(mol, molecule.Molecule)
-        getatomdictfromrmg(mol)
-    elseif pybuiltin(:isinstance)(mol, fragment.Fragment)
         mol.assign_representative_molecule()
         getatomdictfromrmg(mol.mol_repr)
-    else
-        @error("Unrecognizable molecule type $mol")
     end
 end
 export getatomdictadjlist

--- a/src/Parse.jl
+++ b/src/Parse.jl
@@ -161,7 +161,16 @@ function getatomdictfromrmg(mol)
     molecularweight = mol.get_molecular_weight()
     return atmD,nbonds,molecularweight
 end
-getatomdictsmiles(smiles) = getatomdictfromrdkit(Chem.AddHs(Chem.MolFromSmiles(smiles)))
+function getatomdictsmiles(smiles)
+    if occursin(r"R", smiles) || occursin(r"L", smiles)
+        mol = fragment.Fragment().from_smiles_like_string(smiles)
+        mol.assign_representative_molecule()
+        getatomdictfromrmg(mol.mol_repr)
+    else
+        getatomdictfromrdkit(Chem.AddHs(Chem.MolFromSmiles(smiles)))
+    end
+end
+
 export getatomdictsmiles
 getatomdictinchi(inchi) = getatomdictfromrdkit(Chem.AddHs(Chem.MolFromInchi(inchi)))
 export getatomdictinchi


### PR DESCRIPTION
RDKit can't handle fragment smiles. Use RMG's smiles parser for fragments. Refactor the code for adjlist parser for fragments as there's no point to check if the target is fragment twice.