### PR TITLE
quick fix to allow vapor liquid interface to accept T as function

### DIFF
--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -392,14 +392,20 @@ function VaporLiquidMassTransferInternalInterfaceConstantT(domaingas,domainliq,i
     T = domainliq.T
     phase = domainliq.phase
     ignoremasstransferspcinds = getinterfaceignoremasstransferspcinds(domaingas,domainliq,ignoremasstransferspcnames)
-    kLAs = [kLA(T=T) for kLA in getfield.(phase.species,:liquidvolumetricmasstransfercoefficient)]
-    kHs = [kH(T=T) for kH in getfield.(phase.species,:henrylawconstant)]
+    kLAs = [kLA(T=T(0)) for kLA in getfield.(phase.species,:liquidvolumetricmasstransfercoefficient)]
+    kHs = [kH(T=T(0)) for kH in getfield.(phase.species,:henrylawconstant)]
     return VaporLiquidMassTransferInternalInterfaceConstantT(domaingas,domainliq,ignoremasstransferspcnames,ignoremasstransferspcinds,kLAs,kHs,[1,length(domainliq.phase.species)],[0,0],ones(length(domainliq.phase.species))),ones(length(domainliq.phase.species))
 end
 export VaporLiquidMassTransferInternalInterfaceConstantT
 
+
+
+
+
 function getkLAkHs(vl::VaporLiquidMassTransferInternalInterfaceConstantT,Tgas,Tliq)
-    return vl.kLAs, vl.kHs
+	kLAs = [kLA(T=Tliq) for kLA in getfield.(vl.domainliq.phase.species,:liquidvolumetricmasstransfercoefficient)]
+	kHs = [kH(T=Tliq) for kH in getfield.(vl.domainliq.phase.species,:henrylawconstant)]
+    return kLAs, kHs
 end
 
 function evaluate(vl::VaporLiquidMassTransferInternalInterfaceConstantT,dydt,Vgas,Vliq,Tgas,Tliq,N1,N2,P1,P2,Cvave1,Cvave2,ns1,ns2,Us1,Us2,cstot,p)


### PR DESCRIPTION
VaporLiquidMassTransferInternalInterfaceConstantT raises an error when T is passed as a function of time because the construction of the kLA and kH arrays expects T to be a constant. @hwpang helped me to call the function for T when the kLA/kH arrays are constructed. Improvements could me made so that the arrays are not constructed every time the Interface is evaluated, but this works for now.