### PR TITLE
Suppress unnecessary warnings

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,6 @@
+import Logging
+Logging.disable_logging(Logging.Warn)
+
 using Documenter, ReactionMechanismSimulator
 
 makedocs(

--- a/src/ReactionMechanismSimulator.jl
+++ b/src/ReactionMechanismSimulator.jl
@@ -1,3 +1,6 @@
+import Logging
+Logging.disable_logging(Logging.Warn)
+
 module ReactionMechanismSimulator
     using PyCall
     push!(PyVector(pyimport("sys")["path"]), "")

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -1,5 +1,5 @@
 using SciMLBase
-import SciMLBase: AbstractODESolution, HermiteInterpolation, AbstractDiffEqInterpolation
+import SciMLBase: AbstractODESolution, HermiteInterpolation
 using DiffEqSensitivity
 using ForwardDiff
 using OrdinaryDiffEq.PreallocationTools

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -2,7 +2,7 @@ using SciMLBase
 import SciMLBase: AbstractODESolution, HermiteInterpolation
 using DiffEqSensitivity
 using ForwardDiff
-using OrdinaryDiffEq.PreallocationTools
+using PreallocationTools
 
 abstract type AbstractSimulation end
 export AbstractSimulation

--- a/src/rmstest.jl
+++ b/src/rmstest.jl
@@ -1,3 +1,6 @@
+import Logging
+Logging.disable_logging(Logging.Warn)
+
 using PyCall
 const Chem = PyNULL()
 const molecule = PyNULL()


### PR DESCRIPTION
Attempting to disable this warning to show up as RMG-Py users freak out when seeing Julia error message.

```
┌ Warning: Error requiring `EnzymeCore` from `KernelAbstractions`
│   exception =
│    LoadError: UndefVarError: EnzymeRules not defined
│    Stacktrace:
│      [1] top-level scope
│        @ ~/.julia/packages/KernelAbstractions/SQ66B/ext/EnzymeExt.jl:7
│      [2] include(mod::Module, _path::String)
│        @ Base ./Base.jl:419
│      [3] include(x::String)
│        @ KernelAbstractions ~/.julia/packages/KernelAbstractions/SQ66B/src/KernelAbstractions.jl:1
│      [4] top-level scope
│        @ ~/.julia/packages/Requires/Z8rfN/src/Requires.jl:40
│      [5] eval
│        @ ./boot.jl:368 [inlined]
│      [6] eval
│        @ ~/.julia/packages/KernelAbstractions/SQ66B/src/KernelAbstractions.jl:1 [inlined]
│      [7] (::KernelAbstractions.var"#26#29")()
│        @ KernelAbstractions ~/.julia/packages/Requires/Z8rfN/src/require.jl:101
│      [8] macro expansion
│        @ timing.jl:382 [inlined]
│      [9] err(f::Any, listener::Module, modname::String, file::String, line::Any)
│        @ Requires ~/.julia/packages/Requires/Z8rfN/src/require.jl:47
│     [10] (::KernelAbstractions.var"#25#28")()
│        @ KernelAbstractions ~/.julia/packages/Requires/Z8rfN/src/require.jl:100
│     [11] withpath(f::Any, path::String)
│        @ Requires ~/.julia/packages/Requires/Z8rfN/src/require.jl:37
│     [12] (::KernelAbstractions.var"#24#27")()
│        @ KernelAbstractions ~/.julia/packages/Requires/Z8rfN/src/require.jl:99
│     [13] #invokelatest#2
│        @ ./essentials.jl:729 [inlined]
│     [14] invokelatest
│        @ ./essentials.jl:726 [inlined]
│     [15] foreach(f::typeof(Base.invokelatest), itr::Vector{Function})
│        @ Base ./abstractarray.jl:2774
│     [16] loadpkg(pkg::Base.PkgId)
│        @ Requires ~/.julia/packages/Requires/Z8rfN/src/require.jl:27
│     [17] #invokelatest#2
│        @ ./essentials.jl:729 [inlined]
│     [18] invokelatest
│        @ ./essentials.jl:726 [inlined]
│     [19] run_package_callbacks(modkey::Base.PkgId)
│        @ Base ./loading.jl:869
│     [20] _tryrequire_from_serialized(modkey::Base.PkgId, path::String, sourcepath::String, depmods::Vector{Any})
│        @ Base ./loading.jl:944
│     [21] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String, build_id::UInt64)
│        @ Base ./loading.jl:1028
│     [22] _require(pkg::Base.PkgId)
│        @ Base ./loading.jl:1315
│     [23] _require_prelocked(uuidkey::Base.PkgId)
│        @ Base ./loading.jl:1200
│     [24] macro expansion
│        @ ./loading.jl:1180 [inlined]
│     [25] macro expansion
│        @ ./lock.jl:223 [inlined]
│     [26] require(into::Module, mod::Symbol)
│        @ Base ./loading.jl:1144
│     [27] include(fname::String)
│        @ Base.MainInclude ./client.jl:[476](https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/actions/runs/6866648766/job/19105591218#step:9:477)
│     [28] top-level scope
│        @ ~/work/ReactionMechanismSimulator.jl/ReactionMechanismSimulator.jl/src/rmstest.jl:37
│     [29] include(fname::String)
│        @ Base.MainInclude ./client.jl:476
│     [30] top-level scope
│        @ ~/work/ReactionMechanismSimulator.jl/ReactionMechanismSimulator.jl/test/runtests.jl:2
│     [31] include(fname::String)
│        @ Base.MainInclude ./client.jl:476
│     [32] top-level scope
│        @ none:6
│     [33] eval
│        @ ./boot.jl:368 [inlined]
│     [34] exec_options(opts::Base.JLOptions)
│        @ Base ./client.jl:276
│     [35] _start()
│        @ Base ./client.jl:522
│    in expression starting at /home/runner/.julia/packages/KernelAbstractions/SQ66B/ext/EnzymeExt.jl:1
└ @ Requires ~/.julia/packages/Requires/Z8rfN/src/require.jl:51
```