### PR TITLE
Optimize Threaded Sensitivities

### DIFF
--- a/src/ThreadedSensitivities.jl
+++ b/src/ThreadedSensitivities.jl
@@ -161,13 +161,8 @@ Combine ODE solutions into a sensitivity solution
 function generatesenssolution(sol, sensdict, sensprob)
     ts = sol.t
     ordkeys = sort([x for x in keys(sensdict)])
-    u = deepcopy(sol.u)
-    for k in ordkeys
-        for i in 1:length(u)
-            u[i] = vcat(u[i], sensdict[k](ts[i]))
-        end
-    end
     bigsol = build_solution(sensprob, sol.alg, ts, u;
         interp=LinearInterpolation(ts, u), retcode=sol.retcode)
+    u = [vcat(sol.u[i],(sensdict[k](ts[i]) for k in ordkeys)...) for i in 1:length(sol.u)]
     return bigsol
 end


### PR DESCRIPTION
This PR 
1) Keeps us to one deepcopy of Reactor per thread, speeding up solution
2) Greatly improves the speed of combining the solutions into one solution object (in fact this seems to have accidentally been the slowest operation before so I've seen this result in ~4-5x speed up overall)
3) Newer versions of julia do not seem to be happy with multiple threads modifying the same dictionary causing the operation to crash so this PR switches to using a vector instead to store solutions