### PR TITLE
Modify the Marcus branch to allow PCET reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ RMS has been used in many applications:
 ## How to cite
 Please include the following citations for ReactionMechanismSimulator.jl in general and for transitory sensitivities and the automatic mechanism analysis toolkit respectively. 
 
-- <div class="csl-entry">Johnson, M. S., Pang, H.-W., Payne, A. M., &#38; Green, W. H. (2023). <i>ReactionMechanismSimulator.jl: A Modern Approach to Chemical Kinetic Mechanism Simulation and Analysis</i>. https://doi.org/10.26434/CHEMRXIV-2023-TJ34T</div>
+- <div class="csl-entry">Johnson, M. S., Pang, H.-W., Payne, A. M., &#38; Green, W. H. (2023). <i>ReactionMechanismSimulator.jl: A Modern Approach to Chemical Kinetic Mechanism Simulation and Analysis</i>. Int. J. Chem. Kinet. 2024;1-16 https://doi.org/10.1002/kin.21753</div>
 - <div class="csl-entry">Johnson, M. S., McGill, C. J., &#38; Green, W. H. (2022). <i>Transitory Sensitivity in Automatic Chemical Kinetic Mechanism Analysis</i>. https://doi.org/10.26434/CHEMRXIV-2022-ZSFJC</div>
 
 ## Installation

--- a/src/Calculators/Rate.jl
+++ b/src/Calculators/Rate.jl
@@ -27,15 +27,16 @@ end
 @inline (arr::StickingCoefficient)(T::Q;P::N=0.0,C::S=0.0,phi=0.0,dGrxn=0.0,d=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath min(arr.A*T^arr.n*exp(-arr.Ea/(R*T)),1.0)
 export StickingCoefficient
 
-@with_kw struct Arrheniusq{N<:Real,K<:Real,Q<:Real,P<:AbstractRateUncertainty,B} <: AbstractRate
+@with_kw struct Arrheniusq{N<:Real,K<:Real,Q<:Real,R<:Real,P<:AbstractRateUncertainty,B} <: AbstractRate
         A::N
         n::K
         Ea::Q
         q::B = 0.0
+        V0::R = 0.0
         unc::P = EmptyRateUncertainty()
 end
-@inline (arr::Arrheniusq)(;T::Q,P::N=0.0,C::S=0.0,phi=0.0,dGrxn=0.0,d=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath arr.A*T^arr.n*exp((-arr.Ea-arr.q*F*phi)/(R*T))
-@inline (arr::Arrheniusq)(T::Q;P::N=0.0,C::S=0.0,phi=0.0,dGrxn=0.0,d=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath arr.A*T^arr.n*exp((-arr.Ea-arr.q*F*phi)/(R*T))
+@inline (arr::Arrheniusq)(;T::Q,P::N=0.0,C::S=0.0,phi=0.0,dGrxn=0.0,d=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath arr.A*T^arr.n*exp((-arr.Ea-arr.q*F*(phi-arr.V0))/(R*T))
+@inline (arr::Arrheniusq)(T::Q;P::N=0.0,C::S=0.0,phi=0.0,dGrxn=0.0,d=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath arr.A*T^arr.n*exp((-arr.Ea-arr.q*F*(phi-arr.V0))/(R*T))
 export Arrheniusq
 
 @with_kw struct Marcus{N<:Real,K<:Real,Q,P<:AbstractRateUncertainty,B} <: AbstractRate
@@ -248,7 +249,7 @@ export getkineticstype
 
 @inline extracttypename(typ::Symbol) = string(typ)
 @inline extracttypename(typ) = string(typ.name)
-    
+
 @inline function _calcdkdCeff(tbarr::ThirdBody,T::Float64,Ceff::Float64)
     return @fastmath tbarr.arr(T)
 end

--- a/src/Calculators/Ratevec.jl
+++ b/src/Calculators/Ratevec.jl
@@ -21,7 +21,7 @@ function Arrheniusvec(arrs::T) where {T<:AbstractArray}
     end
     return Arrheniusvec(A=A,n=n,Ea=Ea)
 end
-@inline (arr::Arrheniusvec)(;T::Q,P::N=0.0,C::S=0.0,phi=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath @inbounds arr.A.*exp.(arr.n.*log(T).-arr.Ea.*(1.0/(R*T)))
+@inline (arr::Arrheniusvec)(;T::Q,P::N=0.0,C::S=0.0,phi=0.0,dGrxns=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath @inbounds arr.A.*exp.(arr.n.*log(T).-arr.Ea.*(1.0/(R*T)))
 @inline (arr::Arrheniusvec)(T::Q;P::N=0.0,C::S=0.0,phi=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath @inbounds arr.A.*exp.(arr.n.*log(T).-arr.Ea.*(1.0/(R*T)))
 export Arrheniusvec
 
@@ -86,7 +86,7 @@ export getredtemp
 end
 export getredpress
 
-@inline function (ch::Chebyshevvec)(;T::N,P::Q=0.0,C::B=0.0,phi=0.0) where {N<:Real,B<:Real,Q<:Real}
+@inline function (ch::Chebyshevvec)(;T::N,P::Q=0.0,C::B=0.0,phi=0.0,dGrxns=0.0) where {N<:Real,B<:Real,Q<:Real}
     k = zeros(N,size(ch.coefs)[1])
     Tred = getredtemp(ch,T)
     Pred = getredpress(ch,P)
@@ -170,7 +170,7 @@ function Troevec(troes::T) where {T<:AbstractArray}
 end
 export Troevec
     
-@inline function (tr::Troevec)(;T::Q=nothing,P::R=0.0,C::S=nothing,phi=0.0) where {Q<:Real,R<:Real,S<:Real}
+@inline function (tr::Troevec)(;T::Q=nothing,P::R=0.0,C::S=nothing,phi=0.0,dGrxns=0.0) where {Q<:Real,R<:Real,S<:Real}
     k0 = tr.arrlow(T=T)
     kinf = tr.arrhigh(T=T)
     @fastmath Pr = k0.*C./kinf
@@ -201,7 +201,7 @@ function PdepArrheniusvec(pdeparrs::T) where {T<:AbstractArray}
 end
 export PdepArrheniusvec
 
-@inline function (parr::PdepArrheniusvec)(;T::Q=nothing,P::V=nothing,C::S=0.0,phi=0.0) where {Q<:Real,V<:Real,S<:Real}
+@inline function (parr::PdepArrheniusvec)(;T::Q=nothing,P::V=nothing,C::S=0.0,phi=0.0,dGrxns=0.0) where {Q<:Real,V<:Real,S<:Real}
     inds = getBoundingIndsSorted(P,parr.Ps)::Tuple{Int64,Int64}
     if inds[2] == -1
         return @inbounds parr.arrvecs[inds[1]](T=T)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -209,7 +209,7 @@ function upgradekinetics(rxns, domain1, domain2)
             @assert length(spc) == 1
             kin = stickingcoefficient2arrhenius(rxn.kinetics, surfdomain.phase.sitedensity, length(rxn.reactants) - 1, spc[1].molecularweight)
             newrxns[i] = ElementaryReaction(index=rxn.index, reactants=rxn.reactants, reactantinds=rxn.reactantinds, products=rxn.products,
-                productinds=rxn.productinds, kinetics=kin, radicalchange=rxn.radicalchange, reversible=rxn.reversible, forwardable=rxn.forwardable, pairs=rxn.pairs)
+                productinds=rxn.productinds, kinetics=kin, electronchange=rxn.electronchange, radicalchange=rxn.radicalchange, reversible=rxn.reversible, forwardable=rxn.forwardable, pairs=rxn.pairs)
         else
             newrxns[i] = rxn
         end

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -51,7 +51,7 @@ export ReactiveInternalInterface
 
 function getkfskrevs(ri::ReactiveInternalInterface,T1,T2,phi1,phi2,Gs1,Gs2,cstot::Array{Q,1}) where {Q}
     Gpart = ArrayPartition(Gs1,Gs2)
-    dGrxn = -ri.stoichmatrix*Gpart
+    dGrxns = -ri.stoichmatrix*Gpart
     kfs = getkfs(ri,T1,0.0,0.0,Array{Q,1}(),ri.A,phi1,dGrxns,0.0)
     Kc = getKc.(ri.reactions,ri.domain1.phase,ri.domain2.phase,Ref(Gs1),Ref(Gs2),dGrxns,T1,phi1)
     krevs = kfs./Kc

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -95,6 +95,14 @@ function ReactiveInternalInterfaceConstantTPhi(domain1,domain2,reactions,T,A,phi
     M,Nrp1,Nrp2 = getstoichmatrix(domain1,domain2,reactions)
     Gpart = ArrayPartition(domain1.Gs,domain2.Gs)
     dGrxns = -M*Gpart
+    electronchanges = [hasproperty(reaction, :electronchange) ? reaction.electronchange : 0.0 for reaction in reactions]
+    referencepotentials = [hasproperty(reaction.kinetics, :V0) ? reaction.kinetics.V0 : 0.0 for reaction in reactions]
+    if isa(domain1.phase, IdealSurface)
+        phi = domain1.phi !== nothing ? domain1.phi : phi
+    elseif isa(domain2.phase, IdealSurface)
+        phi = domain2.phi !== nothing ? domain2.phi : phi
+    end
+    dGrxns .+= electronchanges.*(phi.-referencepotentials).*F
     kfs = getkf.(reactions,nothing,T,0.0,0.0,Ref([]),A,phi,dGrxns,0.0)
     Kc = getKcs(domain1.phase,domain2.phase,T,Nrp1,Nrp2,dGrxns)
     krevs = kfs./Kc

--- a/src/Parse.jl
+++ b/src/Parse.jl
@@ -168,7 +168,12 @@ function getatomdictsmiles(smiles)
         mol.assign_representative_molecule()
         getatomdictfromrmg(mol.mol_repr)
     else
-        getatomdictfromrdkit(Chem.AddHs(Chem.MolFromSmiles(smiles)))
+        try
+            return getatomdictfromrdkit(Chem.AddHs(Chem.MolFromSmiles(smiles)))
+        catch e
+            println("RDKit parsing failed, using RMG instead", e)
+            return getatomdictfromrmg(molecule.Molecule().from_smiles(smiles))
+        end
     end
 end
 

--- a/src/Phase.jl
+++ b/src/Phase.jl
@@ -41,7 +41,7 @@ function IdealGas(species,reactions; name="",diffusionlimited=false)
     vectuple,vecinds,otherrxns,otherrxninds,posinds = getveckinetics(reactions)
     rxns = vcat(reactions[vecinds],reactions[otherrxninds])
     rxns = [ElementaryReaction(index=i,reactants=rxn.reactants,reactantinds=rxn.reactantinds,
-        products=rxn.products,productinds=rxn.productinds,kinetics=rxn.kinetics,
+        products=rxn.products,productinds=rxn.productinds,kinetics=rxn.kinetics,electronchange=rxn.electronchange,
         radicalchange=rxn.radicalchange,reversible=rxn.reversible,forwardable=rxn.forwardable,pairs=rxn.pairs,comment=rxn.comment) for (i,rxn) in enumerate(rxns)]
     therm = getvecthermo(species)
     rxnarray = getreactionindices(species,rxns)
@@ -80,7 +80,7 @@ function IdealDiluteSolution(species,reactions,solvent; name="",diffusionlimited
     vectuple,vecinds,otherrxns,otherrxninds,posinds = getveckinetics(reactions)
     rxns = vcat(reactions[vecinds],reactions[otherrxninds])
     rxns = [ElementaryReaction(index=i,reactants=rxn.reactants,reactantinds=rxn.reactantinds,
-        products=rxn.products,productinds=rxn.productinds,kinetics=rxn.kinetics,
+        products=rxn.products,productinds=rxn.productinds,kinetics=rxn.kinetics,electronchange=rxn.electronchange,
         radicalchange=rxn.radicalchange,reversible=rxn.reversible,forwardable=rxn.forwardable,pairs=rxn.pairs,comment=rxn.comment) for (i,rxn) in enumerate(rxns)]
     therm = getvecthermo(species)
     rxnarray = getreactionindices(species,rxns)
@@ -120,7 +120,7 @@ function IdealSurface(species,reactions,sitedensity;name="",diffusionlimited=fal
     vectuple,vecinds,otherrxns,otherrxninds,posinds = getveckinetics(reactions)
     rxns = vcat(reactions[vecinds],reactions[otherrxninds])
     rxns = [ElementaryReaction(index=i,reactants=rxn.reactants,reactantinds=rxn.reactantinds,
-        products=rxn.products,productinds=rxn.productinds,kinetics=rxn.kinetics,
+        products=rxn.products,productinds=rxn.productinds,kinetics=rxn.kinetics,electronchange=rxn.electronchange,
         radicalchange=rxn.radicalchange,reversible=rxn.reversible,forwardable=rxn.forwardable,pairs=rxn.pairs,comment=rxn.comment) for (i,rxn) in enumerate(rxns)]
     therm = getvecthermo(species)
     rxnarray = getreactionindices(species,rxns)
@@ -161,7 +161,7 @@ function FragmentBasedIdealFilm(species, reactions; name="", diffusionlimited=fa
     vectuple,vecinds,otherrxns,otherrxninds,posinds = getveckinetics(reactions)
     rxns = vcat(reactions[vecinds],reactions[otherrxninds])
     rxns = [ElementaryReaction(index=i,reactants=rxn.reactants,reactantinds=rxn.reactantinds,
-        products=rxn.products,productinds=rxn.productinds,kinetics=rxn.kinetics,
+        products=rxn.products,productinds=rxn.productinds,kinetics=rxn.kinetics,electronchange=rxn.electronchange,
         radicalchange=rxn.radicalchange,reversible=rxn.reversible,forwardable=rxn.forwardable,pairs=rxn.pairs,
         fragmentbasedreactants=rxn.fragmentbasedreactants,fragmentbasedreactantinds=rxn.fragmentbasedreactantinds,
         fragmentbasedproducts=rxn.fragmentbasedproducts,fragmentbasedproductinds=rxn.fragmentbasedproductinds,

--- a/src/testing/ORR.rms
+++ b/src/testing/ORR.rms
@@ -218,4 +218,11 @@ Reactions:
   radicalchange: 0
   reactants: [H2O2A]
   type: ElementaryReaction
+- kinetics: {A: 6.0e12, lmbd_o: 100000.0, lmbd_i_coefs: [ 2.63844404e+03  9.64948798e+00  7.41268237e-03 -6.10277107e-06], beta: 1.2e10 ,n: 1.0, d: 0.0, type: Marcus}
+  products: [HOOA]
+  radicalchange: 0
+  electronchange: -1
+  reversible: false
+  reactants: [O2A, H+]
+  type: ElementaryReaction
 Units: {}


### PR DESCRIPTION
- [x] Supports electrochemical reactions with non-zero "reference potentials"/"limiting potentials". 
- [x] Updates surface potentials correctly for interfaces (surface-gas, surface-liquid, but not two adjacent surfaces).
- [x] Calculates Gibbs free energy and rate constants correctly for electrochemical reactions on interfaces. 
- [ ] Will use RMG to generate SMILES structure if RDKit fails (for protons). 
- [ ] Includes unit tests to cover Charge Transfer reactions. 