### PR TITLE
Make Arrheniusq Kinetics Compatible With PCET Reactions

### DIFF
--- a/src/Calculators/Rate.jl
+++ b/src/Calculators/Rate.jl
@@ -27,15 +27,16 @@ end
 @inline (arr::StickingCoefficient)(T::Q;P::N=0.0,C::S=0.0,phi=0.0,dGrxn=0.0,d=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath min(arr.A*T^arr.n*exp(-arr.Ea/(R*T)),1.0)
 export StickingCoefficient
 
-@with_kw struct Arrheniusq{N<:Real,K<:Real,Q<:Real,P<:AbstractRateUncertainty,B} <: AbstractRate
+@with_kw struct Arrheniusq{N<:Real,K<:Real,Q<:Real,R<:Real,P<:AbstractRateUncertainty,B} <: AbstractRate
         A::N
         n::K
         Ea::Q
         q::B = 0.0
+        V0::R = 0.0
         unc::P = EmptyRateUncertainty()
 end
-@inline (arr::Arrheniusq)(;T::Q,P::N=0.0,C::S=0.0,phi=0.0,dGrxn=0.0,d=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath arr.A*T^arr.n*exp((-arr.Ea-arr.q*F*phi)/(R*T))
-@inline (arr::Arrheniusq)(T::Q;P::N=0.0,C::S=0.0,phi=0.0,dGrxn=0.0,d=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath arr.A*T^arr.n*exp((-arr.Ea-arr.q*F*phi)/(R*T))
+@inline (arr::Arrheniusq)(;T::Q,P::N=0.0,C::S=0.0,phi=0.0,dGrxn=0.0,d=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath arr.A*T^arr.n*exp((-arr.Ea-arr.q*F*(phi-arr.V0))/(R*T))
+@inline (arr::Arrheniusq)(T::Q;P::N=0.0,C::S=0.0,phi=0.0,dGrxn=0.0,d=0.0) where {Q<:Real,N<:Real,S<:Real} = @fastmath arr.A*T^arr.n*exp((-arr.Ea-arr.q*F*(phi-arr.V0))/(R*T))
 export Arrheniusq
 
 @with_kw struct Marcus{N<:Real,K<:Real,Q,P<:AbstractRateUncertainty,B} <: AbstractRate
@@ -248,7 +249,7 @@ export getkineticstype
 
 @inline extracttypename(typ::Symbol) = string(typ)
 @inline extracttypename(typ) = string(typ.name)
-    
+
 @inline function _calcdkdCeff(tbarr::ThirdBody,T::Float64,Ceff::Float64)
     return @fastmath tbarr.arr(T)
 end

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -95,6 +95,14 @@ function ReactiveInternalInterfaceConstantTPhi(domain1,domain2,reactions,T,A,phi
     M,Nrp1,Nrp2 = getstoichmatrix(domain1,domain2,reactions)
     Gpart = ArrayPartition(domain1.Gs,domain2.Gs)
     dGrxns = -M*Gpart
+    electronchanges = [hasproperty(reaction, :electronchange) ? reaction.electronchange : 0.0 for reaction in reactions]
+    referencepotentials = [hasproperty(reaction.kinetics, :V0) ? reaction.kinetics.V0 : 0.0 for reaction in reactions]
+    if isa(domain1.phase, IdealSurface)
+        phi = domain1.phi !== nothing ? domain1.phi : phi
+    elseif isa(domain2.phase, IdealSurface)
+        phi = domain2.phi !== nothing ? domain2.phi : phi
+    end
+    dGrxns .+= electronchanges.*(phi.-referencepotentials).*F
     kfs = getkf.(reactions,nothing,T,0.0,0.0,Ref([]),A,phi,dGrxns,0.0)
     Kc = getKcs(domain1.phase,domain2.phase,T,Nrp1,Nrp2,dGrxns)
     krevs = kfs./Kc

--- a/src/Parse.jl
+++ b/src/Parse.jl
@@ -168,7 +168,12 @@ function getatomdictsmiles(smiles)
         mol.assign_representative_molecule()
         getatomdictfromrmg(mol.mol_repr)
     else
-        getatomdictfromrdkit(Chem.AddHs(Chem.MolFromSmiles(smiles)))
+        try
+            return getatomdictfromrdkit(Chem.AddHs(Chem.MolFromSmiles(smiles)))
+        catch e
+            println("RDKit parsing failed, using RMG instead", e)
+            return getatomdictfromrmg(molecule.Molecule().from_smiles(smiles))
+        end
     end
 end
 


### PR DESCRIPTION
The `arrheniusq` type kinetics currently does not have reference potential (`V0`) as a parameter and thus assumes `phi` is always measured with respect to SHE. Some electrochemical processes may have different reference potentials such as SCE and Ag/AgCl, and sometimes the reference is defined as the thermal neutral potential. 

Interface reactions such as proton-coupled electron transfer (PCET) also lack a definition for `phi` so their kinetics are currently always evaluated at zero potential. Here we assume `phi` is defined by the applied potential at the surface, with negative values as reduction reactions and positive values as oxidation reactions. The Gibbs free energies now also change with applied potentials so they now have an effect on the equilibrium constant. 